### PR TITLE
removed need to flatten position_ids

### DIFF
--- a/rotobart_utils.py
+++ b/rotobart_utils.py
@@ -15,8 +15,7 @@ def fixed_pos_embedding(x, seq_dim=1, seq_len=None, position_ids=None):
 
     inv_freq = 1. / (10000 ** (np.arange(0, dim, 2) / dim))
 
-    #TODO: Remove the need for flatten!
-    sinusoid_inp = np.einsum('i , j -> i j', position_ids.flatten(), inv_freq)
+    sinusoid_inp = np.einsum('i... , j -> i... j', position_ids, inv_freq)
 
     return np.sin(sinusoid_inp), np.cos(sinusoid_inp)
 
@@ -27,5 +26,5 @@ def rotate_every_two(x):
     return rearrange(x, '... d j -> ... (d j)')
 
 def apply_rotary_pos_emb(x, sincos, offset=0):
-    sin, cos = map(lambda t: repeat(t[offset:x.shape[1]+offset,:], "n d -> () n () (d j)", j=2), sincos)
+    sin, cos = map(lambda t: repeat(t[:, offset:x.shape[1]+offset,:], "b n d -> b n () (d j)", j=2), sincos)
     return (x * cos) + (rotate_every_two(x) * sin)


### PR DESCRIPTION
I am brand new to Jax and einops, so this may be incorrect. However, I think I fixed the need to flatten position_ids, so that we can support batch sizes other than 1. This broke, apply_rotary_pos_emb, so I added the new dimension (b). Let me know if this is way off. 