### PR TITLE
Adds train script

### DIFF
--- a/modeling_flax_rotobart.py
+++ b/modeling_flax_rotobart.py
@@ -919,7 +919,7 @@ class FlaxRotoBARTModule(nn.Module):
             input_ids=decoder_input_ids,
             attention_mask=decoder_attention_mask,
             position_ids=decoder_position_ids,
-            encoder_hidden_states=encoder_outputs[0],
+            encoder_hidden_states=encoder_outputs.last_hidden_state,
             encoder_attention_mask=attention_mask,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,

--- a/rotobart_utils.py
+++ b/rotobart_utils.py
@@ -14,10 +14,8 @@ def fixed_pos_embedding(x, seq_dim=1, seq_len=None, position_ids=None):
         position_ids = np.arange(seq_len)
 
     inv_freq = 1. / (10000 ** (np.arange(0, dim, 2) / dim))
-
-    sinusoid_inp = np.einsum('i... , j -> i... j', position_ids, inv_freq)
-
-    return np.sin(sinusoid_inp), np.cos(sinusoid_inp)
+    sinusoid_inp = jnp.einsum('i... , j -> i... j', position_ids, inv_freq)
+    return jnp.sin(sinusoid_inp), jnp.cos(sinusoid_inp)
 
 def rotate_every_two(x):
     x1 = x[:, :, :, ::2]

--- a/run_dnlm_flax.py
+++ b/run_dnlm_flax.py
@@ -191,6 +191,9 @@ class DataTrainingArguments:
     use_wandb: bool = field(
       default=False, metadata={"help": "Use Weights & Biases for experiment tracking"}
     )
+    testing: bool = field(
+      default=False, metadata={"help": "If testing, only 1 train batch will be used"}
+    )
 
 @flax.struct.dataclass
 class DummyFlaxDataCollatorForRotoBARTMLM:
@@ -548,7 +551,9 @@ if __name__ == "__main__":
     for step in range(num_train_steps):
         # ======================== Training ================================
         try:
-            samples = advance_iter_and_group_samples(training_iter, train_batch_size, max_seq_length)
+            if (data_args.testing and step == 0) or not data_args.testing:
+              samples = advance_iter_and_group_samples(training_iter, train_batch_size, max_seq_length)
+            
         except StopIteration:
             # Once the end of the dataset stream is reached, the training iterator
             # is reinitialized and reshuffled and a new eval dataset is randomely chosen.

--- a/run_dnlm_flax.py
+++ b/run_dnlm_flax.py
@@ -323,6 +323,7 @@ if __name__ == "__main__":
     #   datasets['train'] = datasets['train'].add_item({'text':tmp_text})
     #   datasets['validation'] = datasets['validation'].add_item({'text':tmp_text})
 
+    # Load Datasets
     # Train Dataset - Stream The Pile dataset
     print('Loading train data')
     train_dataset = load_dataset(
@@ -346,7 +347,12 @@ if __name__ == "__main__":
       cache_dir=model_args.cache_dir,
     )
 
-    # Preprocessing the datasets.
+    # Do Setence Permutation on all samples 
+    # permutation = ()
+    # shuffled_train_dataset = shuffled_train_dataset.map(permutation)
+    # eval_dataset = eval_dataset.map(permutation)
+
+    # Do Tokenization
     # Load tokenizer
     tokenizer = BartTokenizerFast.from_pretrained(
         model_args.tokenizer_name, cache_dir=model_args.cache_dir
@@ -367,6 +373,11 @@ if __name__ == "__main__":
         tokenize_function,
         batched=True
     )
+
+    # Do Text Infilling
+    # text_filling = ()
+    # tokenized_train_dataset = tokenized_train_dataset.map(text_filling)
+    # tokenized_eval_dataset = tokenized_eval_dataset.map(text_filling)
 
     # # TODO: Maybe remove this? 
     # # create "decoder_input_ids" and "labels" data for model inputs

--- a/run_dnlm_flax.py
+++ b/run_dnlm_flax.py
@@ -20,6 +20,7 @@ import logging
 import os
 import sys
 import time
+from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -39,12 +40,10 @@ from transformers import (
     CONFIG_MAPPING,
     FLAX_MODEL_FOR_MASKED_LM_MAPPING,
     BatchEncoding,
-    #FlaxT5ForConditionalGeneration,
     HfArgumentParser,
     PreTrainedTokenizerBase,
-    # T5Config,
-    # T5TokenizerFast,
     BartTokenizerFast,
+    TensorType,
     TrainingArguments,
     is_tensorboard_available,
     set_seed,
@@ -180,18 +179,15 @@ class DataTrainingArguments:
         default=3.0,
         metadata={"help": "Mean span length of masked tokens"},
     )
-
-    def __post_init__(self):
-        if self.dataset_name is None and self.train_file is None and self.validation_file is None:
-            raise ValueError("Need either a dataset name or a training/validation file.")
-        else:
-            if self.train_file is not None:
-                extension = self.train_file.split(".")[-1]
-                assert extension in ["csv", "json", "txt"], "`train_file` should be a csv, a json or a txt file."
-            if self.validation_file is not None:
-                extension = self.validation_file.split(".")[-1]
-                assert extension in ["csv", "json", "txt"], "`validation_file` should be a csv, a json or a txt file."
-
+    shuffle_buffer_size: int = field(
+        default=10000, metadata={"help": "The number of examples to pre-load for shuffling."}
+    )
+    num_train_steps: int = field(
+      default=50000, metadata={"help": "The number of training steps."}
+    )
+    num_eval_samples: int = field(
+      default=50000, metadata={"help": "The number of samples to be used for evaluation"}
+    )
 
 @flax.struct.dataclass
 class DummyFlaxDataCollatorForRotoBARTMLM:
@@ -205,18 +201,13 @@ class DummyFlaxDataCollatorForRotoBARTMLM:
 
     def __call__(self, examples: List[Dict[str, np.ndarray]]) -> Dict[str, np.ndarray]:
 
-        # convert list to dict and tensorize input
-        batch = BatchEncoding(
-            {k: np.array([examples[i][k] for i in range(len(examples))]) for k, v in examples[0].items()}
-        )
+        batch = self.tokenizer.pad(examples, return_tensors=TensorType.NUMPY)
 
-        input_ids = batch["input_ids"]
-        batch_size, expandend_input_length = input_ids.shape
+        # If special token mask has been preprocessed, pop it from the dict.
+        special_tokens_mask = batch.pop("special_tokens_mask", None)
 
-        # to check that tokens are correctly proprocessed, one can run `self.tokenizer.batch_decode(input_ids)` and `self.tokenizer.batch_decode(labels)` here...
-        batch["decoder_input_ids"] = shift_tokens_right(
-            batch["labels"], self.pad_token_id, self.decoder_start_token_id
-        )
+        batch["decoder_input_ids"] = batch["input_ids"]
+        batch["labels"] = batch["input_ids"]
 
         return batch
 
@@ -232,7 +223,36 @@ def generate_batch_splits(samples_idx: jnp.ndarray, batch_size: int) -> jnp.ndar
     return batch_idx
 
 
-def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
+def advance_iter_and_group_samples(train_iterator, num_samples, max_seq_length):
+    """
+    The training iterator is advanced so that after groupifying the samples,
+    `num_samples` of length `max_seq_length` are returned.
+    """
+    num_total_tokens = max_seq_length * num_samples
+    samples = defaultdict(list)
+
+    i = 0
+    while i < num_total_tokens:
+        tokenized_samples = next(train_iterator)
+        i += len(tokenized_samples["input_ids"])
+
+        # concatenate tokenized samples to list
+        samples = {k: samples[k] + tokenized_samples[k] for k in tokenized_samples.keys()}
+
+    # Concatenated tokens are split to lists of length `max_seq_length`.
+    # Note that remainedr of % max_seq_length are thrown away.
+    def group_texts(examples):
+        result = {
+            k: [t[i : i + max_seq_length] for i in range(0, num_total_tokens, max_seq_length)]
+            for k, t in examples.items()
+        }
+        return result
+
+    grouped_samples = group_texts(samples)
+    return grouped_samples
+
+
+def write_train_metric(summary_writer, train_metrics, train_time, step):
     summary_writer.scalar("train_time", train_time, step)
 
     train_metrics = get_metrics(train_metrics)
@@ -241,6 +261,8 @@ def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
         for i, val in enumerate(vals):
             summary_writer.scalar(tag, val, step - len(vals) + i + 1)
 
+
+def write_eval_metric(summary_writer, eval_metrics, step):
     for metric_name, value in eval_metrics.items():
         summary_writer.scalar(f"eval_{metric_name}", value, step)
 
@@ -291,151 +313,72 @@ if __name__ == "__main__":
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
-    # TODO: Replace this with the Pile
-    datasets = load_dataset("tiny_shakespeare")
-    tmp_text = """Lorem ipsum dolor sit amet, consectetur adipiscing 
-    elit, sed do eiusmod tempor incididunt ut labore et dolore 
-    magna aliqua. Nec feugiat
-    """
-    for i in range(200):
-      datasets['train'] = datasets['train'].add_item({'text':tmp_text})
-      datasets['validation'] = datasets['validation'].add_item({'text':tmp_text})
+    # # TODO: Replace this with the Pile
+    # datasets = load_dataset("tiny_shakespeare")
+    # tmp_text = """Lorem ipsum dolor sit amet, consectetur adipiscing 
+    # elit, sed do eiusmod tempor incididunt ut labore et dolore 
+    # magna aliqua. Nec feugiat
+    # """
+    # for i in range(200):
+    #   datasets['train'] = datasets['train'].add_item({'text':tmp_text})
+    #   datasets['validation'] = datasets['validation'].add_item({'text':tmp_text})
 
-    # # TODO: Get Pile Data
-    # # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
-    # # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
-    # # (the dataset will be downloaded automatically from the datasets Hub).
-    # #
-    # # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
-    # # 'text' is found. You can easily tweak this behavior (see below).
-    # if data_args.dataset_name is not None:
-    #     # Downloading and loading a dataset from the hub.
-    #     datasets = load_dataset(data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir)
+    # Train Dataset - Stream The Pile dataset
+    print('Loading train data')
+    train_dataset = load_dataset(
+      "./pile.py", 
+      split="train",
+      cache_dir=model_args.cache_dir,
+      streaming=True)
 
-    #     if "validation" not in datasets.keys():
-    #         datasets["validation"] = load_dataset(
-    #             data_args.dataset_name,
-    #             data_args.dataset_config_name,
-    #             split=f"train[:{data_args.validation_split_percentage}%]",
-    #             cache_dir=model_args.cache_dir,
-    #         )
-    #         datasets["train"] = load_dataset(
-    #             data_args.dataset_name,
-    #             data_args.dataset_config_name,
-    #             split=f"train[{data_args.validation_split_percentage}%:]",
-    #             cache_dir=model_args.cache_dir,
-    #         )
-    # else:
-    #     data_files = {}
-    #     if data_args.train_file is not None:
-    #         data_files["train"] = data_args.train_file
-    #     if data_args.validation_file is not None:
-    #         data_files["validation"] = data_args.validation_file
-    #     extension = data_args.train_file.split(".")[-1]
-    #     if extension == "txt":
-    #         extension = "text"
-    #     datasets = load_dataset(extension, data_files=data_files, cache_dir=model_args.cache_dir)
+    # Shuffle the training dataset
+    shuffled_train_dataset = train_dataset.shuffle(
+      buffer_size=data_args.shuffle_buffer_size,
+      seed=training_args.seed
+    )
+    
+    print('Loading eval data')
+    # Test Dataset - Stream The Pile dataset
+    eval_dataset = load_dataset(
+      "./pile.py",
+      split="test",
+      streaming=True,
+      cache_dir=model_args.cache_dir,
+    )
 
-    # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
-    # https://huggingface.co/docs/datasets/loading_datasets.html.
-
-
+    # Preprocessing the datasets.
     # Load tokenizer
     tokenizer = BartTokenizerFast.from_pretrained(
         model_args.tokenizer_name, cache_dir=model_args.cache_dir
     )
 
-    # TODO: Leverage AutoConfig
-    config = RotoBARTConfig(
-      encoder_layers=ModelArguments.encoder_layers,
-      encoder_ffn_dim=ModelArguments.encoder_ffn_dim, 
-      decoder_layers=ModelArguments.decoder_layers, 
-      decoder_ffn_dim=ModelArguments.decoder_ffn_dim
-    )
-
-    # if model_args.config_name:
-    #     config = T5Config.from_pretrained(
-    #         model_args.config_name, cache_dir=model_args.cache_dir, vocab_size=len(tokenizer)
-    #     )
-    # elif model_args.model_name_or_path:
-    #     config = T5Config.from_pretrained(
-    #         model_args.model_name_or_path, cache_dir=model_args.cache_dir, vocab_size=len(tokenizer)
-    #     )
-    # else:
-    #     config = CONFIG_MAPPING[model_args.model_type]()
-    #     logger.warning("You are instantiating a new config instance from scratch.")
-
-    # Preprocessing the datasets.
-    # First we tokenize all the texts.
-    if training_args.do_train:
-        column_names = datasets["train"].column_names
-    else:
-        column_names = datasets["validation"].column_names
-    text_column_name = "text" if "text" in column_names else column_names[0]
-
-    max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
-
-    # Otherwise, we tokenize every text, then concatenate them together before splitting them in smaller parts.
-    # Since we make sure that all sequences are of the same length, no attention_mask is needed.
+    text_column_name = "text" 
     def tokenize_function(examples):
         return tokenizer(examples[text_column_name], return_attention_mask=False)
 
-    tokenized_datasets = datasets.map(
+    print('Tokenizing train data')
+    tokenized_train_dataset = shuffled_train_dataset.map(
         tokenize_function,
-        batched=True,
-        num_proc=data_args.preprocessing_num_workers,
-        remove_columns=column_names,
-        load_from_cache_file=not data_args.overwrite_cache,
+        batched=True
     )
 
-    # TODO: Maybe remove this? 
-    # create "decoder_input_ids" and "labels" data for model inputs
-    def add_decoder_ids_labels(examples):
-      return {
-          "decoder_input_ids": examples['input_ids'],
-          "labels": examples['input_ids'],
-          }  
-    # print(datasets["train"].column_names)
-    tokenized_datasets = tokenized_datasets.map(
-      add_decoder_ids_labels, batched=True
+    print('Tokenizing eval data')
+    tokenized_eval_dataset = eval_dataset.map(
+        tokenize_function,
+        batched=True
     )
 
-    # Main data processing function that will concatenate all texts from our dataset and generate chunks of expanded_inputs_length.
-    def group_texts(examples):
-        # Concatenate all texts.
-        concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
-        total_length = len(concatenated_examples[list(examples.keys())[0]])
-        
-        # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
-        # customize this part to your needs.
-        #total_length = (total_length // expanded_inputs_length) * expanded_inputs_length
-        
-        #TODO: Review this code!!
-        # Split by chunks of max_len.
-        result = {
-            k: [t[i : i + data_args.max_seq_length] for i in range(0, total_length, data_args.max_seq_length)]
-            for k, t in concatenated_examples.items()
-        }
-
-        # # Split by chunks of max_len.
-        # result = {
-        #     k: [t[i : i + expanded_inputs_length] for i in range(0, total_length, expanded_inputs_length)]
-        #     for k, t in concatenated_examples.items()
-        # }
-        return result
-
-    # Note that with `batched=True`, this map processes 1,000 texts together, so group_texts throws away a
-    # remainder for each of those groups of 1,000 texts. You can adjust that batch_size here but a higher value
-    # might be slower to preprocess.
-    #
-    # To speed up this part, we use multiprocessing. See the documentation of the map method for more information:
-    # https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.map
-    tokenized_datasets = tokenized_datasets.map(
-        group_texts,
-        batched=True,
-        num_proc=data_args.preprocessing_num_workers,
-        load_from_cache_file=not data_args.overwrite_cache,
-    )
+    # # TODO: Maybe remove this? 
+    # # create "decoder_input_ids" and "labels" data for model inputs
+    # def add_decoder_ids_labels(examples):
+    #   return {
+    #       "decoder_input_ids": examples['input_ids'],
+    #       "labels": examples['input_ids'],
+    #       }  
+    # # print(datasets["train"].column_names)
+    # tokenized_datasets = tokenized_datasets.map(
+    #   add_decoder_ids_labels, batched=True
+    # )
 
     # Enable tensorboard only on the master node
     has_tensorboard = is_tensorboard_available()
@@ -460,24 +403,20 @@ if __name__ == "__main__":
     dropout_rngs = jax.random.split(rng, jax.local_device_count())
 
     # Load Model
+    # TODO: Leverage AutoConfig
+    config = RotoBARTConfig(
+      encoder_layers=ModelArguments.encoder_layers,
+      encoder_ffn_dim=ModelArguments.encoder_ffn_dim, 
+      decoder_layers=ModelArguments.decoder_layers, 
+      decoder_ffn_dim=ModelArguments.decoder_ffn_dim
+    )
+
     # TODO: Load model from config
     #model = FlaxAutoModelForMaskedLM.from_config(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
-    model = FlaxRotoBARTForConditionalGeneration(config=config)
+    model = FlaxRotoBARTForConditionalGeneration(config=config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
     
-    # model = FlaxT5ForConditionalGeneration(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
-
     # Data collator
-    # This one will take care of randomly masking the tokens.
-    # data_collator = FlaxDataCollatorForT5MLM(
-    #     tokenizer=tokenizer,
-    #     noise_density=data_args.mlm_probability,
-    #     mean_noise_span_length=data_args.mean_noise_span_length,
-    #     input_length=max_seq_length,
-    #     target_length=targets_length,
-    #     pad_token_id=model.config.pad_token_id,
-    #     decoder_start_token_id=model.config.decoder_start_token_id,
-    # )
-
+    max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
     data_collator = DummyFlaxDataCollatorForRotoBARTMLM(
       tokenizer=tokenizer,
       input_length=max_seq_length,
@@ -490,7 +429,8 @@ if __name__ == "__main__":
     train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
     eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
 
-    num_train_steps = len(tokenized_datasets["train"]) // train_batch_size * num_epochs
+    # define number steps per stream epoch
+    num_train_steps = data_args.num_train_steps
 
     # Create learning rate schedule
     warmup_fn = optax.linear_schedule(
@@ -509,12 +449,12 @@ if __name__ == "__main__":
     # to bias and LayerNorm scale parameters. decay_mask_fn returns a
     # mask boolean with the same structure as the parameters.
     # The mask is True for parameters that should be decayed.
+    # Note that this mask is specifically adapted for FlaxBERT-like models.
+    # For other models, one should correct the layer norm parameter naming
+    # accordingly.
     def decay_mask_fn(params):
         flat_params = traverse_util.flatten_dict(params)
-        flat_mask = {
-            path: (path[-1] != "bias" and path[-2:] not in [("layer_norm", "scale"), ("final_layer_norm", "scale")])
-            for path in flat_params
-        }
+        flat_mask = {path: (path[-1] != "bias" and path[-2:] != ("LayerNorm", "scale")) for path in flat_params}
         return traverse_util.unflatten_dict(flat_mask)
 
     # create adam optimizer
@@ -522,6 +462,7 @@ if __name__ == "__main__":
         learning_rate=linear_decay_lr_schedule_fn,
         b1=training_args.adam_beta1,
         b2=training_args.adam_beta2,
+        eps=training_args.adam_epsilon,
         weight_decay=training_args.weight_decay,
         mask=decay_mask_fn,
     )
@@ -529,21 +470,23 @@ if __name__ == "__main__":
     # Setup train state
     state = train_state.TrainState.create(apply_fn=model.__call__, params=model.params, tx=adamw)
 
+    def loss_fn(logits, labels):
+        shift_logits = logits[..., :-1, :]
+        shift_labels = labels[..., 1:]
+        loss = optax.softmax_cross_entropy(shift_logits, onehot(shift_labels, shift_logits.shape[-1]))
+        return loss.mean()
+
     # Define gradient update step fn
     def train_step(state, batch, dropout_rng):
         dropout_rng, new_dropout_rng = jax.random.split(dropout_rng)
 
-        def loss_fn(params):
+        def compute_loss(params):
             labels = batch.pop("labels")
-
             logits = state.apply_fn(**batch, params=params, dropout_rng=dropout_rng, train=True)[0]
-
-            # compute loss
-            loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])).mean()
-
+            loss = loss_fn(logits, labels)
             return loss
 
-        grad_fn = jax.value_and_grad(loss_fn)
+        grad_fn = jax.value_and_grad(compute_loss)
         loss, grad = grad_fn(state.params)
         grad = jax.lax.pmean(grad, "batch")
         new_state = state.apply_gradients(grads=grad)
@@ -563,15 +506,16 @@ if __name__ == "__main__":
 
         logits = model(**batch, params=params, train=False)[0]
 
-        # compute loss
-        loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1]))
+        # compute loss, ignore padded input tokens
+        label_mask = jnp.where(labels > 0, 1.0, 0.0)
+        loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])) * label_mask
 
         # compute accuracy
-        accuracy = jnp.equal(jnp.argmax(logits, axis=-1), labels)
+        accuracy = jnp.equal(jnp.argmax(logits, axis=-1), labels) * label_mask
 
         # summarize metrics
-        metrics = {"loss": loss.mean(), "accuracy": accuracy.mean()}
-        metrics = jax.lax.pmean(metrics, axis_name="batch")
+        metrics = {"loss": loss.sum(), "accuracy": accuracy.sum(), "normalizer": label_mask.sum()}
+        metrics = jax.lax.psum(metrics, axis_name="batch")
 
         return metrics
 
@@ -581,807 +525,89 @@ if __name__ == "__main__":
     state = jax_utils.replicate(state)
 
     train_time = 0
-    epochs = tqdm(range(num_epochs), desc=f"Epoch ... (1/{num_epochs})", position=0)
-    for epoch in epochs:
+    train_start = time.time()
+    train_metrics = []
+    eval_metrics = []
+
+    training_iter = iter(tokenized_train_dataset)
+    eval_iter = iter(tokenized_eval_dataset)
+
+    print('Get eval samples')
+    max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
+    eval_samples = advance_iter_and_group_samples(eval_iter, data_args.num_eval_samples, max_seq_length)
+
+    print('Start training')
+    steps = tqdm(range(num_train_steps), desc="Training...", position=0)
+    for step in range(num_train_steps):
         # ======================== Training ================================
-        train_start = time.time()
-        train_metrics = []
+        try:
+            samples = advance_iter_and_group_samples(training_iter, train_batch_size, max_seq_length)
+        except StopIteration:
+            # Once the end of the dataset stream is reached, the training iterator
+            # is reinitialized and reshuffled and a new eval dataset is randomely chosen.
+            shuffle_seed += 1
+            tokenized_datasets.set_epoch(shuffle_seed)
 
-        # Create sampling rng
-        rng, input_rng = jax.random.split(rng)
+            training_iter = iter(tokenized_train_dataset)
 
-        # Generate an epoch by shuffling sampling indices from the train dataset
-        num_train_samples = len(tokenized_datasets["train"])
-        train_samples_idx = jax.random.permutation(input_rng, jnp.arange(num_train_samples))
-        train_batch_idx = generate_batch_splits(train_samples_idx, train_batch_size)
+            eval_dataset = advance_iter_and_group_samples(eval_iter, data_args.num_eval_samples, max_seq_length)
+            samples = advance_iter_and_group_samples(training_iter, train_batch_size, max_seq_length)
 
-        # Gather the indexes for creating the batch and do a training step
-        for i, batch_idx in enumerate(tqdm(train_batch_idx, desc="Training...", position=1)):
-            samples = [tokenized_datasets["train"][int(idx)] for idx in batch_idx]
-            model_inputs = data_collator(samples)
+        # process input samples
+        model_inputs = data_collator(samples)
 
-            # Model forward
-            model_inputs = shard(model_inputs.data)
-            state, train_metric, dropout_rngs = p_train_step(state, model_inputs, dropout_rngs)
-            train_metrics.append(train_metric)
+        # Model forward
+        model_inputs = shard(model_inputs.data)
+        state, train_metric, dropout_rngs = p_train_step(state, model_inputs, dropout_rngs)
 
-        train_time += time.time() - train_start
+        train_metrics.append(train_metric)
 
-        epochs.write(
-            f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss'].mean()}, Learning Rate: {train_metric['learning_rate'].mean()})"
-        )
+        if step % training_args.logging_steps == 0 and step > 0:
+            steps.write(
+                f"Step... ({step} | Loss: {train_metric['loss'].mean()}, Learning Rate: {train_metric['learning_rate'].mean()})"
+            )
+            train_time += time.time() - train_start
+            if has_tensorboard and jax.process_index() == 0:
+                write_train_metric(summary_writer, train_metrics, train_time, step)
+            train_metrics = []
 
         # ======================== Evaluating ==============================
-        num_eval_samples = len(tokenized_datasets["validation"])
-        eval_samples_idx = jnp.arange(num_eval_samples)
-        eval_batch_idx = generate_batch_splits(eval_samples_idx, eval_batch_size)
-
-        eval_metrics = []
-        for i, batch_idx in enumerate(tqdm(eval_batch_idx, desc="Evaluating ...", position=2)):
-            samples = [tokenized_datasets["validation"][int(idx)] for idx in batch_idx]
-            model_inputs = data_collator(samples)
-
-            # Model forward
-            model_inputs = shard(model_inputs.data)
-            metrics = p_eval_step(state.params, model_inputs)
-            eval_metrics.append(metrics)
-
-        # get eval metrics
-        eval_metrics = get_metrics(eval_metrics)
-        eval_metrics = jax.tree_map(jnp.mean, eval_metrics)
-
-        # Update progress bar
-        epochs.write(
-            f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {eval_metrics['loss']}, Acc: {eval_metrics['accuracy']})"
-        )
-
-        # Save metrics
-        if has_tensorboard and jax.process_index() == 0:
-            cur_step = epoch * (len(tokenized_datasets["train"]) // train_batch_size)
-            write_metric(summary_writer, train_metrics, eval_metrics, train_time, cur_step)
-
-        # save checkpoint after each epoch and push checkpoint to the hub
-        if jax.process_index() == 0:
-            params = jax.device_get(jax.tree_map(lambda x: x[0], state.params))
-            model.save_pretrained(training_args.output_dir, params=params, push_to_hub=training_args.push_to_hub)
-
-
-
-
-# # ============================
-
-# #!/usr/bin/env python
-# # coding=utf-8
-# # Copyright 2021 The HuggingFace Team All rights reserved.
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License");
-# # you may not use this file except in compliance with the License.
-# # You may obtain a copy of the License at
-# #
-# #     http://www.apache.org/licenses/LICENSE-2.0
-# #
-# # Unless required by applicable law or agreed to in writing, software
-# # distributed under the License is distributed on an "AS IS" BASIS,
-# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# # See the License for the specific language governing permissions and
-# # limitations under the License.
-# """
-# Fine-tuning the library models for masked language modeling (BERT, ALBERT, RoBERTa...) with whole word masking on a
-# text file or a dataset.
-
-# Here is the full list of checkpoints on the hub that can be fine-tuned by this script:
-# https://huggingface.co/models?filter=masked-lm
-# """
-# import logging
-# import os
-# import sys
-# import time
-# from dataclasses import dataclass, field
-
-# # You can also adapt this script on your own masked language modeling task. Pointers for this are left as comments.
-# from pathlib import Path
-# from typing import Dict, List, Optional, Tuple
-
-# import numpy as np
-# from datasets import load_dataset
-# from tqdm import tqdm
-
-# import flax
-# import jax
-# import jax.numpy as jnp
-# import optax
-# from flax import jax_utils, traverse_util
-# from flax.training import train_state
-# from flax.training.common_utils import get_metrics, onehot, shard
-# from transformers import (
-#     CONFIG_MAPPING,
-#     FLAX_MODEL_FOR_MASKED_LM_MAPPING,
-#     AutoConfig,
-#     AutoTokenizer,
-#     FlaxAutoModelForMaskedLM,
-#     HfArgumentParser,
-#     PreTrainedTokenizerBase,
-#     TensorType,
-#     TrainingArguments,
-#     is_tensorboard_available,
-#     set_seed,
-# )
-
-# # RotoBART imports
-# from modeling_flax_rotobart import *
-# from configuration_rotobart import *
-# from transformers import BartTokenizer
-
-# # Setup Colab TPU
-# print("Setting up colab TPU")
-# import jax.tools.colab_tpu
-# jax.tools.colab_tpu.setup_tpu()
-# print(f"Colab TPU setup complete, jax.device_count: {jax.device_count()}")
-
-# # Cache the result
-# has_tensorboard = is_tensorboard_available()
-# if has_tensorboard:
-#     try:
-#         from flax.metrics.tensorboard import SummaryWriter
-#     except ImportError as ie:
-#         has_tensorboard = False
-#         print(f"Unable to display metrics through TensorBoard because some package are not installed: {ie}")
-
-# else:
-#     print(
-#         "Unable to display metrics through TensorBoard because the package is not installed: "
-#         "Please run pip install tensorboard to enable."
-#     )
-
-
-# MODEL_CONFIG_CLASSES = list(FLAX_MODEL_FOR_MASKED_LM_MAPPING.keys())
-# MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
-
-
-# @dataclass
-# class ModelArguments:
-#     """
-#     Arguments pertaining to which model/config/tokenizer we are going to fine-tune, or train from scratch.
-#     """
-
-#     model_name_or_path: Optional[str] = field(
-#         default=None,
-#         metadata={
-#             "help": "The model checkpoint for weights initialization."
-#             "Don't set if you want to train a model from scratch."
-#         },
-#     )
-#     model_type: Optional[str] = field(
-#         default=None,
-#         metadata={"help": "If training from scratch, pass a model type from the list: " + ", ".join(MODEL_TYPES)},
-#     )
-#     config_name: Optional[str] = field(
-#         default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
-#     )
-#     tokenizer_name: Optional[str] = field(
-#         default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
-#     )
-#     cache_dir: Optional[str] = field(
-#         default=None, metadata={"help": "Where do you want to store the pretrained models downloaded from s3"}
-#     )
-#     use_fast_tokenizer: bool = field(
-#         default=True,
-#         metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
-#     )
-#     dtype: Optional[str] = field(
-#         default="float32",
-#         metadata={
-#             "help": "Floating-point format in which the model weights should be initialized and trained. Choose one of `[float32, float16, bfloat16]`."
-#         },
-#     )
-#     encoder_layers: Optional[int] = field(
-#         default=2,
-#         metadata={
-#             "help": "Number of encoder layers"
-#         },
-#     )
-#     decoder_layers: Optional[int] = field(
-#         default=2,
-#         metadata={
-#             "help": "Number of decoder layers"
-#         },
-#     )
-#     encoder_ffn_dim: Optional[int] = field(
-#         default=256,
-#         metadata={
-#             "help": "Dimension of encoder feedforward network"
-#         },
-#     )
-#     decoder_ffn_dim: Optional[int] = field(
-#         default=256,
-#         metadata={
-#             "help": "Dimension of decoder feedforward network"
-#         },
-#     )
-
-
-# @dataclass
-# class DataTrainingArguments:
-#     """
-#     Arguments pertaining to what data we are going to input our model for training and eval.
-#     """
-
-#     dataset_name: Optional[str] = field(
-#         default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
-#     )
-#     dataset_config_name: Optional[str] = field(
-#         default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
-#     )
-#     train_file: Optional[str] = field(default=None, metadata={"help": "The input training data file (a text file)."})
-#     validation_file: Optional[str] = field(
-#         default=None,
-#         metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
-#     )
-#     train_ref_file: Optional[str] = field(
-#         default=None,
-#         metadata={"help": "An optional input train ref data file for whole word masking in Chinese."},
-#     )
-#     validation_ref_file: Optional[str] = field(
-#         default=None,
-#         metadata={"help": "An optional input validation ref data file for whole word masking in Chinese."},
-#     )
-#     overwrite_cache: bool = field(
-#         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
-#     )
-#     validation_split_percentage: Optional[int] = field(
-#         default=5,
-#         metadata={
-#             "help": "The percentage of the train set used as validation set in case there's no validation split"
-#         },
-#     )
-#     max_seq_length: Optional[int] = field(
-#         default=None,
-#         metadata={
-#             "help": "The maximum total input sequence length after tokenization. Sequences longer "
-#             "than this will be truncated. Default to the max input length of the model."
-#         },
-#     )
-#     preprocessing_num_workers: Optional[int] = field(
-#         default=None,
-#         metadata={"help": "The number of processes to use for the preprocessing."},
-#     )
-#     mlm_probability: float = field(
-#         default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
-#     )
-#     pad_to_max_length: bool = field(
-#         default=False,
-#         metadata={
-#             "help": "Whether to pad all samples to `max_seq_length`. "
-#             "If False, will pad the samples dynamically when batching to the maximum length in the batch."
-#         },
-#     )
-#     line_by_line: bool = field(
-#         default=False,
-#         metadata={"help": "Whether distinct lines of text in the dataset are to be handled as distinct sequences."},
-#     )
-
-#     def __post_init__(self):
-#         if self.dataset_name is None and self.train_file is None and self.validation_file is None:
-#             raise ValueError("Need either a dataset name or a training/validation file.")
-#         else:
-#             if self.train_file is not None:
-#                 extension = self.train_file.split(".")[-1]
-#                 assert extension in ["csv", "json", "txt"], "`train_file` should be a csv, a json or a txt file."
-#             if self.validation_file is not None:
-#                 extension = self.validation_file.split(".")[-1]
-#                 assert extension in ["csv", "json", "txt"], "`validation_file` should be a csv, a json or a txt file."
-
-
-# @flax.struct.dataclass
-# class FlaxDataCollatorForLanguageModeling:
-#     """
-#     Data collator used for language modeling. Inputs are dynamically padded to the maximum length of a batch if they
-#     are not all of the same length.
-
-#     Args:
-#         tokenizer (:class:`~transformers.PreTrainedTokenizer` or :class:`~transformers.PreTrainedTokenizerFast`):
-#             The tokenizer used for encoding the data.
-#         mlm_probability (:obj:`float`, `optional`, defaults to 0.15):
-#             The probability with which to (randomly) mask tokens in the input.
-
-#     .. note::
-
-#         For best performance, this data collator should be used with a dataset having items that are dictionaries or
-#         BatchEncoding, with the :obj:`"special_tokens_mask"` key, as returned by a
-#         :class:`~transformers.PreTrainedTokenizer` or a :class:`~transformers.PreTrainedTokenizerFast` with the
-#         argument :obj:`return_special_tokens_mask=True`.
-#     """
-
-#     tokenizer: PreTrainedTokenizerBase
-#     mlm_probability: float = 0.15
-
-#     def __post_init__(self):
-#         if self.tokenizer.mask_token is None:
-#             raise ValueError(
-#                 "This tokenizer does not have a mask token which is necessary for masked language modeling. "
-#                 "You should pass `mlm=False` to train on causal language modeling instead."
-#             )
-
-#     def __call__(self, examples: List[Dict[str, np.ndarray]], pad_to_multiple_of: int) -> Dict[str, np.ndarray]:
-#         # Handle dict or lists with proper padding and conversion to tensor.
-#         batch = self.tokenizer.pad(examples, pad_to_multiple_of=pad_to_multiple_of, return_tensors=TensorType.NUMPY)
-
-#         # If special token mask has been preprocessed, pop it from the dict.
-#         special_tokens_mask = batch.pop("special_tokens_mask", None)
-
-#         batch["input_ids"], batch["labels"] = self.mask_tokens(
-#             batch["input_ids"], special_tokens_mask=special_tokens_mask
-#         )
-#         return batch
-
-#     def mask_tokens(
-#         self, inputs: np.ndarray, special_tokens_mask: Optional[np.ndarray]
-#     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
-#         """
-#         Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
-#         """
-#         labels = inputs.copy()
-#         # We sample a few tokens in each sequence for MLM training (with probability `self.mlm_probability`)
-#         probability_matrix = np.full(labels.shape, self.mlm_probability)
-#         special_tokens_mask = special_tokens_mask.astype("bool")
-
-#         probability_matrix[special_tokens_mask] = 0.0
-#         masked_indices = np.random.binomial(1, probability_matrix).astype("bool")
-#         labels[~masked_indices] = -100  # We only compute loss on masked tokens
-
-#         # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
-#         indices_replaced = np.random.binomial(1, np.full(labels.shape, 0.8)).astype("bool") & masked_indices
-#         inputs[indices_replaced] = self.tokenizer.convert_tokens_to_ids(self.tokenizer.mask_token)
-
-#         # 10% of the time, we replace masked input tokens with random word
-#         indices_random = np.random.binomial(1, np.full(labels.shape, 0.5)).astype("bool")
-#         indices_random &= masked_indices & ~indices_replaced
-
-#         random_words = np.random.randint(self.tokenizer.vocab_size, size=labels.shape, dtype="i4")
-#         inputs[indices_random] = random_words[indices_random]
-
-#         # The rest of the time (10% of the time) we keep the masked input tokens unchanged
-#         return inputs, labels
-
-
-# # def data_loader(rng: jax.random.PRNGKey, dataset: Dataset, batch_size: int, shuffle: bool = False):
-# #     """
-# #     Returns batches of size `batch_size` from truncated `dataset`, sharded over all local devices.
-# #     Shuffle batches if `shuffle` is `True`.
-# #     """
-# #     steps_per_epoch = len(dataset) // batch_size
-
-# #     if shuffle:
-# #         batch_idx = jax.random.permutation(rng, len(dataset))
-# #     else:
-# #         batch_idx = jnp.arange(len(dataset))
-
-# #     batch_idx = batch_idx[: steps_per_epoch * batch_size]  # Skip incomplete batch.
-# #     batch_idx = batch_idx.reshape((steps_per_epoch, batch_size))
-
-# #     for idx in batch_idx:
-# #         batch = dataset[idx]
-# #         batch = {k: jnp.array(v) for k, v in batch.items()}
-
-# #         batch = shard(batch)
-
-# #         yield batch
-
-# def generate_batch_splits(samples_idx: jnp.ndarray, batch_size: int) -> jnp.ndarray:
-#     num_samples = len(samples_idx)
-#     samples_to_remove = num_samples % batch_size
-
-#     if samples_to_remove != 0:
-#         samples_idx = samples_idx[:-samples_to_remove]
-#     sections_split = num_samples // batch_size
-#     batch_idx = np.split(samples_idx, sections_split)
-#     return batch_idx
-
-
-# def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
-#     summary_writer.scalar("train_time", train_time, step)
-
-#     train_metrics = get_metrics(train_metrics)
-#     for key, vals in train_metrics.items():
-#         tag = f"train_{key}"
-#         for i, val in enumerate(vals):
-#             summary_writer.scalar(tag, val, step - len(vals) + i + 1)
-
-#     for metric_name, value in eval_metrics.items():
-#         summary_writer.scalar(f"eval_{metric_name}", value, step)
-
-
-# if __name__ == "__main__":
-#     # See all possible arguments in src/transformers/training_args.py
-#     # or by passing the --help flag to this script.
-#     # We now keep distinct sets of args, for a cleaner separation of concerns.
-
-#     parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments))
-#     if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
-#         # If we pass only one argument to the script and it's the path to a json file,
-#         # let's parse it to get our arguments.
-#         model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
-#     else:
-#         model_args, data_args, training_args = parser.parse_args_into_dataclasses()
-
-#     if (
-#         os.path.exists(training_args.output_dir)
-#         and os.listdir(training_args.output_dir)
-#         and training_args.do_train
-#         and not training_args.overwrite_output_dir
-#     ):
-#         raise ValueError(
-#             f"Output directory ({training_args.output_dir}) already exists and is not empty."
-#             "Use --overwrite_output_dir to overcome."
-#         )
-
-#     # TODO: Fix/remove logging
-#     # # Setup logging
-#     # logging.basicConfig(
-#     #     format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
-#     #     level="NOTSET",
-#     #     datefmt="[%X]",
-#     # )
-
-#     # # Log on each process the small summary:
-#     # logger = logging.getLogger(__name__)
-#     # logger.warning(
-#     #     f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
-#     #     + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
-#     # )
-
-#     # Set the verbosity to info of the Transformers logger (on main process only):
-#     # logger.info(f"Training/evaluation parameters {training_args}")
-
-#     # Set seed before initializing model.
-#     set_seed(training_args.seed)
-
-#     # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
-#     # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
-#     # (the dataset will be downloaded automatically from the datasets Hub).
-#     #
-#     # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
-#     # 'text' is found. You can easily tweak this behavior (see below).
-#     #
-#     # In distributed training, the load_dataset function guarantees that only one local process can concurrently
-#     # download the dataset.
-#     if data_args.dataset_name is not None:
-#         # Downloading and loading a dataset from the hub.
-#         datasets = load_dataset(data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir)
-
-#         if "validation" not in datasets.keys():
-#             datasets["validation"] = load_dataset(
-#                 data_args.dataset_name,
-#                 data_args.dataset_config_name,
-#                 split=f"train[:{data_args.validation_split_percentage}%]",
-#                 cache_dir=model_args.cache_dir,
-#             )
-#             datasets["train"] = load_dataset(
-#                 data_args.dataset_name,
-#                 data_args.dataset_config_name,
-#                 split=f"train[{data_args.validation_split_percentage}%:]",
-#                 cache_dir=model_args.cache_dir,
-#             )
-#     else:
-#         data_files = {}
-#         if data_args.train_file is not None:
-#             data_files["train"] = data_args.train_file
-#         if data_args.validation_file is not None:
-#             data_files["validation"] = data_args.validation_file
-#         extension = data_args.train_file.split(".")[-1]
-#         if extension == "txt":
-#             extension = "text"
-#         datasets = load_dataset(extension, data_files=data_files, cache_dir=model_args.cache_dir)
-#     # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
-#     # https://huggingface.co/docs/datasets/loading_datasets.html.
-
-#     # Load pretrained model and tokenizer
-
-#     # TODO: Leverage AutoConfig
-#     # Distributed training:
-#     # The .from_pretrained methods guarantee that only one local process can concurrently
-#     # download model & vocab.
-#     # if model_args.config_name:
-#     #     config = AutoConfig.from_pretrained(model_args.config_name, cache_dir=model_args.cache_dir)
-#     # elif model_args.model_name_or_path:
-#     #     config = AutoConfig.from_pretrained(model_args.model_name_or_path, cache_dir=model_args.cache_dir)
-#     # else:
-#     #     config = CONFIG_MAPPING[model_args.model_type]()
-#     #     logger.warning("You are instantiating a new config instance from scratch.")
-
-#     # TODO: Leverage AutoConfig
-#     config = RotoBARTConfig(
-#       encoder_layers=ModelArguments.encoder_layers,
-#       encoder_ffn_dim=ModelArguments.encoder_ffn_dim, 
-#       decoder_layers=ModelArguments.decoder_layers, 
-#       decoder_ffn_dim=ModelArguments.decoder_ffn_dim
-#     )
-
-#     # TODO: Load model from config
-#     #model = FlaxAutoModelForMaskedLM.from_config(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
-#     model = FlaxRotoBARTForConditionalGeneration(config=config)
-
-
-#     # TODO: leverage AutoTokenizer
-#     if model_args.tokenizer_name:
-#         tokenizer = AutoTokenizer.from_pretrained(
-#             model_args.tokenizer_name, cache_dir=model_args.cache_dir, use_fast=model_args.use_fast_tokenizer
-#         )
-#     # elif model_args.model_name_or_path:
-#     #     tokenizer = AutoTokenizer.from_pretrained(
-#     #         model_args.model_name_or_path, cache_dir=model_args.cache_dir, use_fast=model_args.use_fast_tokenizer
-#     #     )
-#     # else:
-#     #     raise ValueError(
-#     #         "You are instantiating a new tokenizer from scratch. This is not supported by this script."
-#     #         "You can do it from another script, save it, and load it from here, using --tokenizer_name."
-#     #     )
-
-#     # Preprocessing the datasets.
-#     # First we tokenize all the texts.
-#     if training_args.do_train:
-#         column_names = datasets["train"].column_names
-#     else:
-#         column_names = datasets["validation"].column_names
-#     text_column_name = "text" if "text" in column_names else column_names[0]
-
-#     max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
-
-#     if data_args.line_by_line:
-#         # When using line_by_line, we just tokenize each nonempty line.
-#         padding = "max_length" if data_args.pad_to_max_length else False
-
-#         def tokenize_function(examples):
-#             # Remove empty lines
-#             examples = [line for line in examples if len(line) > 0 and not line.isspace()]
-#             return tokenizer(
-#                 examples,
-#                 return_special_tokens_mask=True,
-#                 padding=padding,
-#                 truncation=True,
-#                 max_length=max_seq_length,
-#             )
-
-#         tokenized_datasets = datasets.map(
-#             tokenize_function,
-#             input_columns=[text_column_name],
-#             batched=True,
-#             num_proc=data_args.preprocessing_num_workers,
-#             remove_columns=column_names,
-#             load_from_cache_file=not data_args.overwrite_cache,
-#         )
-
-#     else:
-#         # Otherwise, we tokenize every text, then concatenate them together before splitting them in smaller parts.
-#         # We use `return_special_tokens_mask=True` because DataCollatorForLanguageModeling (see below) is more
-#         # efficient when it receives the `special_tokens_mask`.
-#         def tokenize_function(examples):
-#             return tokenizer(examples[text_column_name], return_special_tokens_mask=True)
-
-#         tokenized_datasets = datasets.map(
-#             tokenize_function,
-#             batched=True,
-#             num_proc=data_args.preprocessing_num_workers,
-#             remove_columns=column_names,
-#             load_from_cache_file=not data_args.overwrite_cache,
-#         )
-
-#         # Main data processing function that will concatenate all texts from our dataset and generate chunks of
-#         # max_seq_length.
-#         def group_texts(examples):
-#             # Concatenate all texts.
-#             concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
-#             total_length = len(concatenated_examples[list(examples.keys())[0]])
-#             # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
-#             # customize this part to your needs.
-#             total_length = (total_length // max_seq_length) * max_seq_length
-#             # Split by chunks of max_len.
-#             result = {
-#                 k: [t[i : i + max_seq_length] for i in range(0, total_length, max_seq_length)]
-#                 for k, t in concatenated_examples.items()
-#             }
-#             return result
-
-#         # Note that with `batched=True`, this map processes 1,000 texts together, so group_texts throws away a
-#         # remainder for each of those groups of 1,000 texts. You can adjust that batch_size here but a higher value
-#         # might be slower to preprocess.
-#         #
-#         # To speed up this part, we use multiprocessing. See the documentation of the map method for more information:
-#         # https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.map
-#         tokenized_datasets = tokenized_datasets.map(
-#             group_texts,
-#             batched=True,
-#             num_proc=data_args.preprocessing_num_workers,
-#             load_from_cache_file=not data_args.overwrite_cache,
-#         )
-
-#     # Enable tensorboard only on the master node
-#     if has_tensorboard and jax.process_index() == 0:
-#         summary_writer = SummaryWriter(log_dir=Path(training_args.output_dir))
-
-#     # Data collator
-#     # This one will take care of randomly masking the tokens.
-#     data_collator = FlaxDataCollatorForLanguageModeling(tokenizer=tokenizer, mlm_probability=data_args.mlm_probability)
-
-#     # Initialize our training
-#     rng = jax.random.PRNGKey(training_args.seed)
-#     dropout_rngs = jax.random.split(rng, jax.local_device_count())
-
-#     # TODO: Load model from config
-#     #model = FlaxAutoModelForMaskedLM.from_config(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
-#     model = FlaxRotoBARTForConditionalGeneration(config=config)
-
-#     # Store some constant
-#     num_epochs = int(training_args.num_train_epochs)
-#     train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
-#     eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
-
-#     num_train_steps = len(tokenized_datasets["train"]) // train_batch_size * num_epochs
-
-#     # Create learning rate schedule
-#     warmup_fn = optax.linear_schedule(
-#         init_value=0.0, end_value=training_args.learning_rate, transition_steps=training_args.warmup_steps
-#     )
-#     decay_fn = optax.linear_schedule(
-#         init_value=training_args.learning_rate,
-#         end_value=0,
-#         transition_steps=num_train_steps - training_args.warmup_steps,
-#     )
-#     linear_decay_lr_schedule_fn = optax.join_schedules(
-#         schedules=[warmup_fn, decay_fn], boundaries=[training_args.warmup_steps]
-#     )
-
-#     # We use Optax's "masking" functionality to not apply weight decay
-#     # to bias and LayerNorm scale parameters. decay_mask_fn returns a
-#     # mask boolean with the same structure as the parameters.
-#     # The mask is True for parameters that should be decayed.
-#     # Note that this mask is specifically adapted for FlaxBERT-like models.
-#     # For other models, one should correct the layer norm parameter naming
-#     # accordingly.
-#     def decay_mask_fn(params):
-#         flat_params = traverse_util.flatten_dict(params)
-#         flat_mask = {path: (path[-1] != "bias" and path[-2:] != ("LayerNorm", "scale")) for path in flat_params}
-#         return traverse_util.unflatten_dict(flat_mask)
-
-#     # create adam optimizer
-#     adamw = optax.adamw(
-#         learning_rate=linear_decay_lr_schedule_fn,
-#         b1=training_args.adam_beta1,
-#         b2=training_args.adam_beta2,
-#         eps=1e-8,
-#         weight_decay=training_args.weight_decay,
-#         mask=decay_mask_fn,
-#     )
-
-#     # Setup train state
-#     state = train_state.TrainState.create(apply_fn=model.__call__, params=model.params, tx=adamw)
-
-#     # Define gradient update step fn
-#     def train_step(state, batch, dropout_rng):
-#         dropout_rng, new_dropout_rng = jax.random.split(dropout_rng)
-
-#         def loss_fn(params):
-#             labels = batch.pop("labels")
-
-#             logits = state.apply_fn(**batch, params=params, dropout_rng=dropout_rng, train=True)[0]
-
-#             # compute loss, ignore padded input tokens
-#             label_mask = jnp.where(labels > 0, 1.0, 0.0)
-#             loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])) * label_mask
-
-#             # take average
-#             loss = loss.sum() / label_mask.sum()
-
-#             return loss
-
-#         grad_fn = jax.value_and_grad(loss_fn)
-#         loss, grad = grad_fn(state.params)
-#         grad = jax.lax.pmean(grad, "batch")
-#         new_state = state.apply_gradients(grads=grad)
-
-#         metrics = jax.lax.pmean(
-#             {"loss": loss, "learning_rate": linear_decay_lr_schedule_fn(state.step)}, axis_name="batch"
-#         )
-
-#         return new_state, metrics, new_dropout_rng
-
-#     # Create parallel version of the train step
-#     p_train_step = jax.pmap(train_step, "batch", donate_argnums=(0,))
-
-#     # Define eval fn
-#     def eval_step(params, batch):
-#         labels = batch.pop("labels")
-
-#         logits = model(**batch, params=params, train=False)[0]
-
-#         # compute loss, ignore padded input tokens
-#         label_mask = jnp.where(labels > 0, 1.0, 0.0)
-#         loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])) * label_mask
-
-#         # compute accuracy
-#         accuracy = jnp.equal(jnp.argmax(logits, axis=-1), labels) * label_mask
-
-#         # summarize metrics
-#         metrics = {"loss": loss.sum(), "accuracy": accuracy.sum(), "normalizer": label_mask.sum()}
-#         metrics = jax.lax.psum(metrics, axis_name="batch")
-
-#         return metrics
-
-#     p_eval_step = jax.pmap(eval_step, "batch", donate_argnums=(0,))
-
-#     # Replicate the train state on each device
-#     state = jax_utils.replicate(state)
-
-#     train_time = 0
-#     epochs = tqdm(range(num_epochs), desc=f"Epoch ... (1/{num_epochs})", position=0)
-#     for epoch in epochs:
-#         # ======================== Training ================================
-#         train_start = time.time()
-#         train_metrics = []
-
-#         # Create sampling rng
-#         rng, input_rng = jax.random.split(rng)
-
-#         # Generate an epoch by shuffling sampling indices from the train dataset
-#         num_train_samples = len(tokenized_datasets["train"])
-#         train_samples_idx = jax.random.permutation(input_rng, jnp.arange(num_train_samples))
-#         train_batch_idx = generate_batch_splits(train_samples_idx, train_batch_size)
-
-#         # Gather the indexes for creating the batch and do a training step
-#         for i, batch_idx in enumerate(tqdm(train_batch_idx, desc="Training...", position=1)):
-#             samples = [tokenized_datasets["train"][int(idx)] for idx in batch_idx]
-#             model_inputs = data_collator(samples, pad_to_multiple_of=16)
-
-#             # Model forward
-#             model_inputs = shard(model_inputs.data)
-#             state, train_metric, dropout_rngs = p_train_step(state, model_inputs, dropout_rngs)
-#             train_metrics.append(train_metric)
-
-#         train_time += time.time() - train_start
-
-#         print(f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})")
-
-#         epochs.write(
-#             f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})"
-#         )
-
-#         # ======================== Evaluating ==============================
-#         num_eval_samples = len(tokenized_datasets["validation"])
-#         eval_samples_idx = jnp.arange(num_eval_samples)
-#         eval_batch_idx = generate_batch_splits(eval_samples_idx, eval_batch_size)
-
-#         eval_metrics = []
-#         for i, batch_idx in enumerate(tqdm(eval_batch_idx, desc="Evaluating ...", position=2)):
-#             samples = [tokenized_datasets["validation"][int(idx)] for idx in batch_idx]
-#             model_inputs = data_collator(samples, pad_to_multiple_of=16)
-
-#             # Model forward
-#             model_inputs = shard(model_inputs.data)
-#             metrics = p_eval_step(state.params, model_inputs)
-#             eval_metrics.append(metrics)
-
-#         # normalize eval metrics
-#         eval_metrics = get_metrics(eval_metrics)
-#         eval_metrics = jax.tree_map(jnp.sum, eval_metrics)
-#         eval_normalizer = eval_metrics.pop("normalizer")
-#         eval_metrics = jax.tree_map(lambda x: x / eval_normalizer, eval_metrics)
-
-#         # Update progress bar
-#         epochs.desc = (
-#             f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {eval_metrics['loss']}, Acc: {eval_metrics['accuracy']})"
-#         )
-
-#         # Save metrics
-#         if has_tensorboard and jax.process_index() == 0:
-#             cur_step = epoch * (len(tokenized_datasets["train"]) // train_batch_size)
-#             write_metric(summary_writer, train_metrics, eval_metrics, train_time, cur_step)
-
-#         # save checkpoint after each epoch and push checkpoint to the hub
-#         if jax.process_index() == 0:
-#             params = jax.device_get(jax.tree_map(lambda x: x[0], state.params))
-#             model.save_pretrained(
-#                 training_args.output_dir,
-#                 params=params,
-#                 push_to_hub=training_args.push_to_hub,
-#                 commit_message=f"Saving weights and logs of epoch {epoch+1}",
-#             )
+        if step % training_args.eval_steps == 0 and step > 0:
+            eval_samples_idx = jnp.arange(data_args.num_eval_samples)
+            eval_batch_idx = generate_batch_splits(eval_samples_idx, eval_batch_size)
+
+            for i, batch_idx in enumerate(tqdm(eval_batch_idx, desc="Evaluating ...", position=1)):
+                # process input samples
+                batch_eval_samples = {k: [v[idx] for idx in batch_idx] for k, v in eval_samples.items()}
+                model_inputs = data_collator(batch_eval_samples)
+
+                # Model forward
+                model_inputs = shard(model_inputs.data)
+                metrics = p_eval_step(state.params, model_inputs)
+                eval_metrics.append(metrics)
+
+            # normalize eval metrics
+            eval_metrics = get_metrics(eval_metrics)
+            eval_metrics = jax.tree_map(jnp.sum, eval_metrics)
+            eval_normalizer = eval_metrics.pop("normalizer")
+            eval_metrics = jax.tree_map(lambda x: x / eval_normalizer, eval_metrics)
+
+            # Update progress bar
+            steps.desc = f"Step... ({step + 1}/{num_train_steps} | Loss: {eval_metrics['loss']}, Acc: {eval_metrics['accuracy']})"
+
+            if has_tensorboard and jax.process_index() == 0:
+                write_eval_metric(summary_writer, eval_metrics, step)
+            eval_metrics = []
+
+            # save checkpoint after each epoch and push checkpoint to the hub
+            if jax.process_index() == 0:
+                params = jax.device_get(jax.tree_map(lambda x: x[0], state.params))
+                model.save_pretrained(
+                    training_args.output_dir,
+                    params=params,
+                    push_to_hub=training_args.push_to_hub,
+                    commit_message=f"Saving weights and logs of step {step+1}",
+                )
+
+        # update tqdm bar
+        steps.update(1)

--- a/run_dnlm_flax.py
+++ b/run_dnlm_flax.py
@@ -55,11 +55,16 @@ from transformers import (
     set_seed,
 )
 
-
+# RotoBART imports
 from modeling_flax_rotobart import *
 from configuration_rotobart import *
 from transformers import BartTokenizer
 
+# Setup Colab TPU
+print("Setting up colab TPU")
+import jax.tools.colab_tpu
+jax.tools.colab_tpu.setup_tpu()
+print(f"Colab TPU setup complete, jax.device_count: {jax.device_count()}")
 
 # Cache the result
 has_tensorboard = is_tensorboard_available()
@@ -676,6 +681,8 @@ if __name__ == "__main__":
             train_metrics.append(train_metric)
 
         train_time += time.time() - train_start
+
+        print(f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})")
 
         epochs.write(
             f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})"

--- a/run_dnlm_flax.py
+++ b/run_dnlm_flax.py
@@ -13,22 +13,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Fine-tuning the library models for masked language modeling (BERT, ALBERT, RoBERTa...) with whole word masking on a
-text file or a dataset.
 
-Here is the full list of checkpoints on the hub that can be fine-tuned by this script:
-https://huggingface.co/models?filter=masked-lm
-"""
+
+# You can also adapt this script on your own masked language modeling task. Pointers for this are left as comments.
 import logging
 import os
 import sys
 import time
 from dataclasses import dataclass, field
-
-# You can also adapt this script on your own masked language modeling task. Pointers for this are left as comments.
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import numpy as np
 from datasets import load_dataset
@@ -44,16 +38,20 @@ from flax.training.common_utils import get_metrics, onehot, shard
 from transformers import (
     CONFIG_MAPPING,
     FLAX_MODEL_FOR_MASKED_LM_MAPPING,
-    AutoConfig,
-    AutoTokenizer,
-    FlaxAutoModelForMaskedLM,
+    BatchEncoding,
+    #FlaxT5ForConditionalGeneration,
     HfArgumentParser,
     PreTrainedTokenizerBase,
-    TensorType,
+    # T5Config,
+    # T5TokenizerFast,
+    BartTokenizerFast,
     TrainingArguments,
     is_tensorboard_available,
     set_seed,
 )
+
+# TODO: import from rotobart file
+from transformers.models.t5.modeling_flax_t5 import shift_tokens_right
 
 # RotoBART imports
 from modeling_flax_rotobart import *
@@ -66,25 +64,8 @@ import jax.tools.colab_tpu
 jax.tools.colab_tpu.setup_tpu()
 print(f"Colab TPU setup complete, jax.device_count: {jax.device_count()}")
 
-# Cache the result
-has_tensorboard = is_tensorboard_available()
-if has_tensorboard:
-    try:
-        from flax.metrics.tensorboard import SummaryWriter
-    except ImportError as ie:
-        has_tensorboard = False
-        print(f"Unable to display metrics through TensorBoard because some package are not installed: {ie}")
-
-else:
-    print(
-        "Unable to display metrics through TensorBoard because the package is not installed: "
-        "Please run pip install tensorboard to enable."
-    )
-
-
-MODEL_CONFIG_CLASSES = list(FLAX_MODEL_FOR_MASKED_LM_MAPPING.keys())
-MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
-
+# MODEL_CONFIG_CLASSES = list(FLAX_MODEL_FOR_MASKED_LM_MAPPING.keys())
+# MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
 
 @dataclass
 class ModelArguments:
@@ -99,10 +80,10 @@ class ModelArguments:
             "Don't set if you want to train a model from scratch."
         },
     )
-    model_type: Optional[str] = field(
-        default=None,
-        metadata={"help": "If training from scratch, pass a model type from the list: " + ", ".join(MODEL_TYPES)},
-    )
+    # model_type: Optional[str] = field(
+    #     default=None,
+    #     metadata={"help": "If training from scratch, pass a model type from the list: " + ", ".join(MODEL_TYPES)},
+    # )
     config_name: Optional[str] = field(
         default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
     )
@@ -185,8 +166,7 @@ class DataTrainingArguments:
     max_seq_length: Optional[int] = field(
         default=None,
         metadata={
-            "help": "The maximum total input sequence length after tokenization. Sequences longer "
-            "than this will be truncated. Default to the max input length of the model."
+            "help": "The maximum total input sequence length after tokenization and masking. Sequences longer than this will be truncated. Default to the max input length of the model."
         },
     )
     preprocessing_num_workers: Optional[int] = field(
@@ -194,18 +174,11 @@ class DataTrainingArguments:
         metadata={"help": "The number of processes to use for the preprocessing."},
     )
     mlm_probability: float = field(
-        default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
+        default=0.15, metadata={"help": "Ratio of tokens to mask for span masked language modeling loss"}
     )
-    pad_to_max_length: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to pad all samples to `max_seq_length`. "
-            "If False, will pad the samples dynamically when batching to the maximum length in the batch."
-        },
-    )
-    line_by_line: bool = field(
-        default=False,
-        metadata={"help": "Whether distinct lines of text in the dataset are to be handled as distinct sequences."},
+    mean_noise_span_length: float = field(
+        default=3.0,
+        metadata={"help": "Mean span length of masked tokens"},
     )
 
     def __post_init__(self):
@@ -221,99 +194,32 @@ class DataTrainingArguments:
 
 
 @flax.struct.dataclass
-class FlaxDataCollatorForLanguageModeling:
+class DummyFlaxDataCollatorForRotoBARTMLM:
     """
-    Data collator used for language modeling. Inputs are dynamically padded to the maximum length of a batch if they
-    are not all of the same length.
-
-    Args:
-        tokenizer (:class:`~transformers.PreTrainedTokenizer` or :class:`~transformers.PreTrainedTokenizerFast`):
-            The tokenizer used for encoding the data.
-        mlm_probability (:obj:`float`, `optional`, defaults to 0.15):
-            The probability with which to (randomly) mask tokens in the input.
-
-    .. note::
-
-        For best performance, this data collator should be used with a dataset having items that are dictionaries or
-        BatchEncoding, with the :obj:`"special_tokens_mask"` key, as returned by a
-        :class:`~transformers.PreTrainedTokenizer` or a :class:`~transformers.PreTrainedTokenizerFast` with the
-        argument :obj:`return_special_tokens_mask=True`.
+      DUMMY DATACOLLATOR
     """
-
     tokenizer: PreTrainedTokenizerBase
-    mlm_probability: float = 0.15
+    input_length: int
+    pad_token_id: int
+    decoder_start_token_id: int
 
-    def __post_init__(self):
-        if self.tokenizer.mask_token is None:
-            raise ValueError(
-                "This tokenizer does not have a mask token which is necessary for masked language modeling. "
-                "You should pass `mlm=False` to train on causal language modeling instead."
-            )
+    def __call__(self, examples: List[Dict[str, np.ndarray]]) -> Dict[str, np.ndarray]:
 
-    def __call__(self, examples: List[Dict[str, np.ndarray]], pad_to_multiple_of: int) -> Dict[str, np.ndarray]:
-        # Handle dict or lists with proper padding and conversion to tensor.
-        batch = self.tokenizer.pad(examples, pad_to_multiple_of=pad_to_multiple_of, return_tensors=TensorType.NUMPY)
-
-        # If special token mask has been preprocessed, pop it from the dict.
-        special_tokens_mask = batch.pop("special_tokens_mask", None)
-
-        batch["input_ids"], batch["labels"] = self.mask_tokens(
-            batch["input_ids"], special_tokens_mask=special_tokens_mask
+        # convert list to dict and tensorize input
+        batch = BatchEncoding(
+            {k: np.array([examples[i][k] for i in range(len(examples))]) for k, v in examples[0].items()}
         )
+
+        input_ids = batch["input_ids"]
+        batch_size, expandend_input_length = input_ids.shape
+
+        # to check that tokens are correctly proprocessed, one can run `self.tokenizer.batch_decode(input_ids)` and `self.tokenizer.batch_decode(labels)` here...
+        batch["decoder_input_ids"] = shift_tokens_right(
+            batch["labels"], self.pad_token_id, self.decoder_start_token_id
+        )
+
         return batch
 
-    def mask_tokens(
-        self, inputs: np.ndarray, special_tokens_mask: Optional[np.ndarray]
-    ) -> Tuple[jnp.ndarray, jnp.ndarray]:
-        """
-        Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
-        """
-        labels = inputs.copy()
-        # We sample a few tokens in each sequence for MLM training (with probability `self.mlm_probability`)
-        probability_matrix = np.full(labels.shape, self.mlm_probability)
-        special_tokens_mask = special_tokens_mask.astype("bool")
-
-        probability_matrix[special_tokens_mask] = 0.0
-        masked_indices = np.random.binomial(1, probability_matrix).astype("bool")
-        labels[~masked_indices] = -100  # We only compute loss on masked tokens
-
-        # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
-        indices_replaced = np.random.binomial(1, np.full(labels.shape, 0.8)).astype("bool") & masked_indices
-        inputs[indices_replaced] = self.tokenizer.convert_tokens_to_ids(self.tokenizer.mask_token)
-
-        # 10% of the time, we replace masked input tokens with random word
-        indices_random = np.random.binomial(1, np.full(labels.shape, 0.5)).astype("bool")
-        indices_random &= masked_indices & ~indices_replaced
-
-        random_words = np.random.randint(self.tokenizer.vocab_size, size=labels.shape, dtype="i4")
-        inputs[indices_random] = random_words[indices_random]
-
-        # The rest of the time (10% of the time) we keep the masked input tokens unchanged
-        return inputs, labels
-
-
-# def data_loader(rng: jax.random.PRNGKey, dataset: Dataset, batch_size: int, shuffle: bool = False):
-#     """
-#     Returns batches of size `batch_size` from truncated `dataset`, sharded over all local devices.
-#     Shuffle batches if `shuffle` is `True`.
-#     """
-#     steps_per_epoch = len(dataset) // batch_size
-
-#     if shuffle:
-#         batch_idx = jax.random.permutation(rng, len(dataset))
-#     else:
-#         batch_idx = jnp.arange(len(dataset))
-
-#     batch_idx = batch_idx[: steps_per_epoch * batch_size]  # Skip incomplete batch.
-#     batch_idx = batch_idx.reshape((steps_per_epoch, batch_size))
-
-#     for idx in batch_idx:
-#         batch = dataset[idx]
-#         batch = {k: jnp.array(v) for k, v in batch.items()}
-
-#         batch = shard(batch)
-
-#         yield batch
 
 def generate_batch_splits(samples_idx: jnp.ndarray, batch_size: int) -> jnp.ndarray:
     num_samples = len(samples_idx)
@@ -363,15 +269,16 @@ if __name__ == "__main__":
             "Use --overwrite_output_dir to overcome."
         )
 
-    # TODO: Fix/remove logging
+    # TODO: Fix logger
     # # Setup logging
     # logging.basicConfig(
-    #     format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    #     format="%(asctime)s - %(levelname)s - %(name)s -   %(message)s",
     #     level="NOTSET",
     #     datefmt="[%X]",
     # )
 
-    # # Log on each process the small summary:
+    # TODO: Fix logger
+    # Log on each process the small summary:
     # logger = logging.getLogger(__name__)
     # logger.warning(
     #     f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
@@ -379,63 +286,64 @@ if __name__ == "__main__":
     # )
 
     # Set the verbosity to info of the Transformers logger (on main process only):
-    # logger.info(f"Training/evaluation parameters {training_args}")
+    #logger.info(f"Training/evaluation parameters {training_args}")
 
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
-    # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
-    # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
-    # (the dataset will be downloaded automatically from the datasets Hub).
-    #
-    # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
-    # 'text' is found. You can easily tweak this behavior (see below).
-    #
-    # In distributed training, the load_dataset function guarantees that only one local process can concurrently
-    # download the dataset.
-    if data_args.dataset_name is not None:
-        # Downloading and loading a dataset from the hub.
-        datasets = load_dataset(data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir)
+    # TODO: Replace this with the Pile
+    datasets = load_dataset("tiny_shakespeare")
+    tmp_text = """Lorem ipsum dolor sit amet, consectetur adipiscing 
+    elit, sed do eiusmod tempor incididunt ut labore et dolore 
+    magna aliqua. Nec feugiat
+    """
+    for i in range(200):
+      datasets['train'] = datasets['train'].add_item({'text':tmp_text})
+      datasets['validation'] = datasets['validation'].add_item({'text':tmp_text})
 
-        if "validation" not in datasets.keys():
-            datasets["validation"] = load_dataset(
-                data_args.dataset_name,
-                data_args.dataset_config_name,
-                split=f"train[:{data_args.validation_split_percentage}%]",
-                cache_dir=model_args.cache_dir,
-            )
-            datasets["train"] = load_dataset(
-                data_args.dataset_name,
-                data_args.dataset_config_name,
-                split=f"train[{data_args.validation_split_percentage}%:]",
-                cache_dir=model_args.cache_dir,
-            )
-    else:
-        data_files = {}
-        if data_args.train_file is not None:
-            data_files["train"] = data_args.train_file
-        if data_args.validation_file is not None:
-            data_files["validation"] = data_args.validation_file
-        extension = data_args.train_file.split(".")[-1]
-        if extension == "txt":
-            extension = "text"
-        datasets = load_dataset(extension, data_files=data_files, cache_dir=model_args.cache_dir)
+    # # TODO: Get Pile Data
+    # # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
+    # # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
+    # # (the dataset will be downloaded automatically from the datasets Hub).
+    # #
+    # # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
+    # # 'text' is found. You can easily tweak this behavior (see below).
+    # if data_args.dataset_name is not None:
+    #     # Downloading and loading a dataset from the hub.
+    #     datasets = load_dataset(data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir)
+
+    #     if "validation" not in datasets.keys():
+    #         datasets["validation"] = load_dataset(
+    #             data_args.dataset_name,
+    #             data_args.dataset_config_name,
+    #             split=f"train[:{data_args.validation_split_percentage}%]",
+    #             cache_dir=model_args.cache_dir,
+    #         )
+    #         datasets["train"] = load_dataset(
+    #             data_args.dataset_name,
+    #             data_args.dataset_config_name,
+    #             split=f"train[{data_args.validation_split_percentage}%:]",
+    #             cache_dir=model_args.cache_dir,
+    #         )
+    # else:
+    #     data_files = {}
+    #     if data_args.train_file is not None:
+    #         data_files["train"] = data_args.train_file
+    #     if data_args.validation_file is not None:
+    #         data_files["validation"] = data_args.validation_file
+    #     extension = data_args.train_file.split(".")[-1]
+    #     if extension == "txt":
+    #         extension = "text"
+    #     datasets = load_dataset(extension, data_files=data_files, cache_dir=model_args.cache_dir)
+
     # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
     # https://huggingface.co/docs/datasets/loading_datasets.html.
 
-    # Load pretrained model and tokenizer
 
-    # TODO: Leverage AutoConfig
-    # Distributed training:
-    # The .from_pretrained methods guarantee that only one local process can concurrently
-    # download model & vocab.
-    # if model_args.config_name:
-    #     config = AutoConfig.from_pretrained(model_args.config_name, cache_dir=model_args.cache_dir)
-    # elif model_args.model_name_or_path:
-    #     config = AutoConfig.from_pretrained(model_args.model_name_or_path, cache_dir=model_args.cache_dir)
-    # else:
-    #     config = CONFIG_MAPPING[model_args.model_type]()
-    #     logger.warning("You are instantiating a new config instance from scratch.")
+    # Load tokenizer
+    tokenizer = BartTokenizerFast.from_pretrained(
+        model_args.tokenizer_name, cache_dir=model_args.cache_dir
+    )
 
     # TODO: Leverage AutoConfig
     config = RotoBARTConfig(
@@ -445,20 +353,17 @@ if __name__ == "__main__":
       decoder_ffn_dim=ModelArguments.decoder_ffn_dim
     )
 
-    # TODO: leverage AutoTokenizer
-    if model_args.tokenizer_name:
-        tokenizer = AutoTokenizer.from_pretrained(
-            model_args.tokenizer_name, cache_dir=model_args.cache_dir, use_fast=model_args.use_fast_tokenizer
-        )
+    # if model_args.config_name:
+    #     config = T5Config.from_pretrained(
+    #         model_args.config_name, cache_dir=model_args.cache_dir, vocab_size=len(tokenizer)
+    #     )
     # elif model_args.model_name_or_path:
-    #     tokenizer = AutoTokenizer.from_pretrained(
-    #         model_args.model_name_or_path, cache_dir=model_args.cache_dir, use_fast=model_args.use_fast_tokenizer
+    #     config = T5Config.from_pretrained(
+    #         model_args.model_name_or_path, cache_dir=model_args.cache_dir, vocab_size=len(tokenizer)
     #     )
     # else:
-    #     raise ValueError(
-    #         "You are instantiating a new tokenizer from scratch. This is not supported by this script."
-    #         "You can do it from another script, save it, and load it from here, using --tokenizer_name."
-    #     )
+    #     config = CONFIG_MAPPING[model_args.model_type]()
+    #     logger.warning("You are instantiating a new config instance from scratch.")
 
     # Preprocessing the datasets.
     # First we tokenize all the texts.
@@ -470,89 +375,115 @@ if __name__ == "__main__":
 
     max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
 
-    if data_args.line_by_line:
-        # When using line_by_line, we just tokenize each nonempty line.
-        padding = "max_length" if data_args.pad_to_max_length else False
+    # Otherwise, we tokenize every text, then concatenate them together before splitting them in smaller parts.
+    # Since we make sure that all sequences are of the same length, no attention_mask is needed.
+    def tokenize_function(examples):
+        return tokenizer(examples[text_column_name], return_attention_mask=False)
 
-        def tokenize_function(examples):
-            # Remove empty lines
-            examples = [line for line in examples if len(line) > 0 and not line.isspace()]
-            return tokenizer(
-                examples,
-                return_special_tokens_mask=True,
-                padding=padding,
-                truncation=True,
-                max_length=max_seq_length,
-            )
+    tokenized_datasets = datasets.map(
+        tokenize_function,
+        batched=True,
+        num_proc=data_args.preprocessing_num_workers,
+        remove_columns=column_names,
+        load_from_cache_file=not data_args.overwrite_cache,
+    )
 
-        tokenized_datasets = datasets.map(
-            tokenize_function,
-            input_columns=[text_column_name],
-            batched=True,
-            num_proc=data_args.preprocessing_num_workers,
-            remove_columns=column_names,
-            load_from_cache_file=not data_args.overwrite_cache,
-        )
+    # TODO: Maybe remove this? 
+    # create "decoder_input_ids" and "labels" data for model inputs
+    def add_decoder_ids_labels(examples):
+      return {
+          "decoder_input_ids": examples['input_ids'],
+          "labels": examples['input_ids'],
+          }  
+    # print(datasets["train"].column_names)
+    tokenized_datasets = tokenized_datasets.map(
+      add_decoder_ids_labels, batched=True
+    )
 
-    else:
-        # Otherwise, we tokenize every text, then concatenate them together before splitting them in smaller parts.
-        # We use `return_special_tokens_mask=True` because DataCollatorForLanguageModeling (see below) is more
-        # efficient when it receives the `special_tokens_mask`.
-        def tokenize_function(examples):
-            return tokenizer(examples[text_column_name], return_special_tokens_mask=True)
+    # Main data processing function that will concatenate all texts from our dataset and generate chunks of expanded_inputs_length.
+    def group_texts(examples):
+        # Concatenate all texts.
+        concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
+        total_length = len(concatenated_examples[list(examples.keys())[0]])
+        
+        # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
+        # customize this part to your needs.
+        #total_length = (total_length // expanded_inputs_length) * expanded_inputs_length
+        
+        #TODO: Review this code!!
+        # Split by chunks of max_len.
+        result = {
+            k: [t[i : i + data_args.max_seq_length] for i in range(0, total_length, data_args.max_seq_length)]
+            for k, t in concatenated_examples.items()
+        }
 
-        tokenized_datasets = datasets.map(
-            tokenize_function,
-            batched=True,
-            num_proc=data_args.preprocessing_num_workers,
-            remove_columns=column_names,
-            load_from_cache_file=not data_args.overwrite_cache,
-        )
+        # # Split by chunks of max_len.
+        # result = {
+        #     k: [t[i : i + expanded_inputs_length] for i in range(0, total_length, expanded_inputs_length)]
+        #     for k, t in concatenated_examples.items()
+        # }
+        return result
 
-        # Main data processing function that will concatenate all texts from our dataset and generate chunks of
-        # max_seq_length.
-        def group_texts(examples):
-            # Concatenate all texts.
-            concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
-            total_length = len(concatenated_examples[list(examples.keys())[0]])
-            # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
-            # customize this part to your needs.
-            total_length = (total_length // max_seq_length) * max_seq_length
-            # Split by chunks of max_len.
-            result = {
-                k: [t[i : i + max_seq_length] for i in range(0, total_length, max_seq_length)]
-                for k, t in concatenated_examples.items()
-            }
-            return result
-
-        # Note that with `batched=True`, this map processes 1,000 texts together, so group_texts throws away a
-        # remainder for each of those groups of 1,000 texts. You can adjust that batch_size here but a higher value
-        # might be slower to preprocess.
-        #
-        # To speed up this part, we use multiprocessing. See the documentation of the map method for more information:
-        # https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.map
-        tokenized_datasets = tokenized_datasets.map(
-            group_texts,
-            batched=True,
-            num_proc=data_args.preprocessing_num_workers,
-            load_from_cache_file=not data_args.overwrite_cache,
-        )
+    # Note that with `batched=True`, this map processes 1,000 texts together, so group_texts throws away a
+    # remainder for each of those groups of 1,000 texts. You can adjust that batch_size here but a higher value
+    # might be slower to preprocess.
+    #
+    # To speed up this part, we use multiprocessing. See the documentation of the map method for more information:
+    # https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.map
+    tokenized_datasets = tokenized_datasets.map(
+        group_texts,
+        batched=True,
+        num_proc=data_args.preprocessing_num_workers,
+        load_from_cache_file=not data_args.overwrite_cache,
+    )
 
     # Enable tensorboard only on the master node
+    has_tensorboard = is_tensorboard_available()
     if has_tensorboard and jax.process_index() == 0:
-        summary_writer = SummaryWriter(log_dir=Path(training_args.output_dir))
+        try:
+            from flax.metrics.tensorboard import SummaryWriter
 
-    # Data collator
-    # This one will take care of randomly masking the tokens.
-    data_collator = FlaxDataCollatorForLanguageModeling(tokenizer=tokenizer, mlm_probability=data_args.mlm_probability)
+            summary_writer = SummaryWriter(log_dir=Path(training_args.output_dir))
+        except ImportError as ie:
+            has_tensorboard = False
+            logger.warning(
+                f"Unable to display metrics through TensorBoard because some package are not installed: {ie}"
+            )
+    else:
+        logger.warning(
+            "Unable to display metrics through TensorBoard because the package is not installed: "
+            "Please run pip install tensorboard to enable."
+        )
 
     # Initialize our training
     rng = jax.random.PRNGKey(training_args.seed)
     dropout_rngs = jax.random.split(rng, jax.local_device_count())
 
+    # Load Model
     # TODO: Load model from config
     #model = FlaxAutoModelForMaskedLM.from_config(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
     model = FlaxRotoBARTForConditionalGeneration(config=config)
+    
+    # model = FlaxT5ForConditionalGeneration(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
+
+    # Data collator
+    # This one will take care of randomly masking the tokens.
+    # data_collator = FlaxDataCollatorForT5MLM(
+    #     tokenizer=tokenizer,
+    #     noise_density=data_args.mlm_probability,
+    #     mean_noise_span_length=data_args.mean_noise_span_length,
+    #     input_length=max_seq_length,
+    #     target_length=targets_length,
+    #     pad_token_id=model.config.pad_token_id,
+    #     decoder_start_token_id=model.config.decoder_start_token_id,
+    # )
+
+    data_collator = DummyFlaxDataCollatorForRotoBARTMLM(
+      tokenizer=tokenizer,
+      input_length=max_seq_length,
+      pad_token_id=tokenizer.pad_token_id,
+      decoder_start_token_id=3 # TODO FIX THIS
+    )
 
     # Store some constant
     num_epochs = int(training_args.num_train_epochs)
@@ -578,12 +509,12 @@ if __name__ == "__main__":
     # to bias and LayerNorm scale parameters. decay_mask_fn returns a
     # mask boolean with the same structure as the parameters.
     # The mask is True for parameters that should be decayed.
-    # Note that this mask is specifically adapted for FlaxBERT-like models.
-    # For other models, one should correct the layer norm parameter naming
-    # accordingly.
     def decay_mask_fn(params):
         flat_params = traverse_util.flatten_dict(params)
-        flat_mask = {path: (path[-1] != "bias" and path[-2:] != ("LayerNorm", "scale")) for path in flat_params}
+        flat_mask = {
+            path: (path[-1] != "bias" and path[-2:] not in [("layer_norm", "scale"), ("final_layer_norm", "scale")])
+            for path in flat_params
+        }
         return traverse_util.unflatten_dict(flat_mask)
 
     # create adam optimizer
@@ -591,7 +522,6 @@ if __name__ == "__main__":
         learning_rate=linear_decay_lr_schedule_fn,
         b1=training_args.adam_beta1,
         b2=training_args.adam_beta2,
-        eps=1e-8,
         weight_decay=training_args.weight_decay,
         mask=decay_mask_fn,
     )
@@ -608,12 +538,8 @@ if __name__ == "__main__":
 
             logits = state.apply_fn(**batch, params=params, dropout_rng=dropout_rng, train=True)[0]
 
-            # compute loss, ignore padded input tokens
-            label_mask = jnp.where(labels > 0, 1.0, 0.0)
-            loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])) * label_mask
-
-            # take average
-            loss = loss.sum() / label_mask.sum()
+            # compute loss
+            loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])).mean()
 
             return loss
 
@@ -637,16 +563,15 @@ if __name__ == "__main__":
 
         logits = model(**batch, params=params, train=False)[0]
 
-        # compute loss, ignore padded input tokens
-        label_mask = jnp.where(labels > 0, 1.0, 0.0)
-        loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])) * label_mask
+        # compute loss
+        loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1]))
 
         # compute accuracy
-        accuracy = jnp.equal(jnp.argmax(logits, axis=-1), labels) * label_mask
+        accuracy = jnp.equal(jnp.argmax(logits, axis=-1), labels)
 
         # summarize metrics
-        metrics = {"loss": loss.sum(), "accuracy": accuracy.sum(), "normalizer": label_mask.sum()}
-        metrics = jax.lax.psum(metrics, axis_name="batch")
+        metrics = {"loss": loss.mean(), "accuracy": accuracy.mean()}
+        metrics = jax.lax.pmean(metrics, axis_name="batch")
 
         return metrics
 
@@ -673,7 +598,7 @@ if __name__ == "__main__":
         # Gather the indexes for creating the batch and do a training step
         for i, batch_idx in enumerate(tqdm(train_batch_idx, desc="Training...", position=1)):
             samples = [tokenized_datasets["train"][int(idx)] for idx in batch_idx]
-            model_inputs = data_collator(samples, pad_to_multiple_of=16)
+            model_inputs = data_collator(samples)
 
             # Model forward
             model_inputs = shard(model_inputs.data)
@@ -682,10 +607,8 @@ if __name__ == "__main__":
 
         train_time += time.time() - train_start
 
-        print(f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})")
-
         epochs.write(
-            f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})"
+            f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss'].mean()}, Learning Rate: {train_metric['learning_rate'].mean()})"
         )
 
         # ======================== Evaluating ==============================
@@ -696,21 +619,19 @@ if __name__ == "__main__":
         eval_metrics = []
         for i, batch_idx in enumerate(tqdm(eval_batch_idx, desc="Evaluating ...", position=2)):
             samples = [tokenized_datasets["validation"][int(idx)] for idx in batch_idx]
-            model_inputs = data_collator(samples, pad_to_multiple_of=16)
+            model_inputs = data_collator(samples)
 
             # Model forward
             model_inputs = shard(model_inputs.data)
             metrics = p_eval_step(state.params, model_inputs)
             eval_metrics.append(metrics)
 
-        # normalize eval metrics
+        # get eval metrics
         eval_metrics = get_metrics(eval_metrics)
-        eval_metrics = jax.tree_map(jnp.sum, eval_metrics)
-        eval_normalizer = eval_metrics.pop("normalizer")
-        eval_metrics = jax.tree_map(lambda x: x / eval_normalizer, eval_metrics)
+        eval_metrics = jax.tree_map(jnp.mean, eval_metrics)
 
         # Update progress bar
-        epochs.desc = (
+        epochs.write(
             f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {eval_metrics['loss']}, Acc: {eval_metrics['accuracy']})"
         )
 
@@ -722,9 +643,745 @@ if __name__ == "__main__":
         # save checkpoint after each epoch and push checkpoint to the hub
         if jax.process_index() == 0:
             params = jax.device_get(jax.tree_map(lambda x: x[0], state.params))
-            model.save_pretrained(
-                training_args.output_dir,
-                params=params,
-                push_to_hub=training_args.push_to_hub,
-                commit_message=f"Saving weights and logs of epoch {epoch+1}",
-            )
+            model.save_pretrained(training_args.output_dir, params=params, push_to_hub=training_args.push_to_hub)
+
+
+
+
+# # ============================
+
+# #!/usr/bin/env python
+# # coding=utf-8
+# # Copyright 2021 The HuggingFace Team All rights reserved.
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+# """
+# Fine-tuning the library models for masked language modeling (BERT, ALBERT, RoBERTa...) with whole word masking on a
+# text file or a dataset.
+
+# Here is the full list of checkpoints on the hub that can be fine-tuned by this script:
+# https://huggingface.co/models?filter=masked-lm
+# """
+# import logging
+# import os
+# import sys
+# import time
+# from dataclasses import dataclass, field
+
+# # You can also adapt this script on your own masked language modeling task. Pointers for this are left as comments.
+# from pathlib import Path
+# from typing import Dict, List, Optional, Tuple
+
+# import numpy as np
+# from datasets import load_dataset
+# from tqdm import tqdm
+
+# import flax
+# import jax
+# import jax.numpy as jnp
+# import optax
+# from flax import jax_utils, traverse_util
+# from flax.training import train_state
+# from flax.training.common_utils import get_metrics, onehot, shard
+# from transformers import (
+#     CONFIG_MAPPING,
+#     FLAX_MODEL_FOR_MASKED_LM_MAPPING,
+#     AutoConfig,
+#     AutoTokenizer,
+#     FlaxAutoModelForMaskedLM,
+#     HfArgumentParser,
+#     PreTrainedTokenizerBase,
+#     TensorType,
+#     TrainingArguments,
+#     is_tensorboard_available,
+#     set_seed,
+# )
+
+# # RotoBART imports
+# from modeling_flax_rotobart import *
+# from configuration_rotobart import *
+# from transformers import BartTokenizer
+
+# # Setup Colab TPU
+# print("Setting up colab TPU")
+# import jax.tools.colab_tpu
+# jax.tools.colab_tpu.setup_tpu()
+# print(f"Colab TPU setup complete, jax.device_count: {jax.device_count()}")
+
+# # Cache the result
+# has_tensorboard = is_tensorboard_available()
+# if has_tensorboard:
+#     try:
+#         from flax.metrics.tensorboard import SummaryWriter
+#     except ImportError as ie:
+#         has_tensorboard = False
+#         print(f"Unable to display metrics through TensorBoard because some package are not installed: {ie}")
+
+# else:
+#     print(
+#         "Unable to display metrics through TensorBoard because the package is not installed: "
+#         "Please run pip install tensorboard to enable."
+#     )
+
+
+# MODEL_CONFIG_CLASSES = list(FLAX_MODEL_FOR_MASKED_LM_MAPPING.keys())
+# MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
+
+
+# @dataclass
+# class ModelArguments:
+#     """
+#     Arguments pertaining to which model/config/tokenizer we are going to fine-tune, or train from scratch.
+#     """
+
+#     model_name_or_path: Optional[str] = field(
+#         default=None,
+#         metadata={
+#             "help": "The model checkpoint for weights initialization."
+#             "Don't set if you want to train a model from scratch."
+#         },
+#     )
+#     model_type: Optional[str] = field(
+#         default=None,
+#         metadata={"help": "If training from scratch, pass a model type from the list: " + ", ".join(MODEL_TYPES)},
+#     )
+#     config_name: Optional[str] = field(
+#         default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
+#     )
+#     tokenizer_name: Optional[str] = field(
+#         default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
+#     )
+#     cache_dir: Optional[str] = field(
+#         default=None, metadata={"help": "Where do you want to store the pretrained models downloaded from s3"}
+#     )
+#     use_fast_tokenizer: bool = field(
+#         default=True,
+#         metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
+#     )
+#     dtype: Optional[str] = field(
+#         default="float32",
+#         metadata={
+#             "help": "Floating-point format in which the model weights should be initialized and trained. Choose one of `[float32, float16, bfloat16]`."
+#         },
+#     )
+#     encoder_layers: Optional[int] = field(
+#         default=2,
+#         metadata={
+#             "help": "Number of encoder layers"
+#         },
+#     )
+#     decoder_layers: Optional[int] = field(
+#         default=2,
+#         metadata={
+#             "help": "Number of decoder layers"
+#         },
+#     )
+#     encoder_ffn_dim: Optional[int] = field(
+#         default=256,
+#         metadata={
+#             "help": "Dimension of encoder feedforward network"
+#         },
+#     )
+#     decoder_ffn_dim: Optional[int] = field(
+#         default=256,
+#         metadata={
+#             "help": "Dimension of decoder feedforward network"
+#         },
+#     )
+
+
+# @dataclass
+# class DataTrainingArguments:
+#     """
+#     Arguments pertaining to what data we are going to input our model for training and eval.
+#     """
+
+#     dataset_name: Optional[str] = field(
+#         default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
+#     )
+#     dataset_config_name: Optional[str] = field(
+#         default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+#     )
+#     train_file: Optional[str] = field(default=None, metadata={"help": "The input training data file (a text file)."})
+#     validation_file: Optional[str] = field(
+#         default=None,
+#         metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
+#     )
+#     train_ref_file: Optional[str] = field(
+#         default=None,
+#         metadata={"help": "An optional input train ref data file for whole word masking in Chinese."},
+#     )
+#     validation_ref_file: Optional[str] = field(
+#         default=None,
+#         metadata={"help": "An optional input validation ref data file for whole word masking in Chinese."},
+#     )
+#     overwrite_cache: bool = field(
+#         default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
+#     )
+#     validation_split_percentage: Optional[int] = field(
+#         default=5,
+#         metadata={
+#             "help": "The percentage of the train set used as validation set in case there's no validation split"
+#         },
+#     )
+#     max_seq_length: Optional[int] = field(
+#         default=None,
+#         metadata={
+#             "help": "The maximum total input sequence length after tokenization. Sequences longer "
+#             "than this will be truncated. Default to the max input length of the model."
+#         },
+#     )
+#     preprocessing_num_workers: Optional[int] = field(
+#         default=None,
+#         metadata={"help": "The number of processes to use for the preprocessing."},
+#     )
+#     mlm_probability: float = field(
+#         default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
+#     )
+#     pad_to_max_length: bool = field(
+#         default=False,
+#         metadata={
+#             "help": "Whether to pad all samples to `max_seq_length`. "
+#             "If False, will pad the samples dynamically when batching to the maximum length in the batch."
+#         },
+#     )
+#     line_by_line: bool = field(
+#         default=False,
+#         metadata={"help": "Whether distinct lines of text in the dataset are to be handled as distinct sequences."},
+#     )
+
+#     def __post_init__(self):
+#         if self.dataset_name is None and self.train_file is None and self.validation_file is None:
+#             raise ValueError("Need either a dataset name or a training/validation file.")
+#         else:
+#             if self.train_file is not None:
+#                 extension = self.train_file.split(".")[-1]
+#                 assert extension in ["csv", "json", "txt"], "`train_file` should be a csv, a json or a txt file."
+#             if self.validation_file is not None:
+#                 extension = self.validation_file.split(".")[-1]
+#                 assert extension in ["csv", "json", "txt"], "`validation_file` should be a csv, a json or a txt file."
+
+
+# @flax.struct.dataclass
+# class FlaxDataCollatorForLanguageModeling:
+#     """
+#     Data collator used for language modeling. Inputs are dynamically padded to the maximum length of a batch if they
+#     are not all of the same length.
+
+#     Args:
+#         tokenizer (:class:`~transformers.PreTrainedTokenizer` or :class:`~transformers.PreTrainedTokenizerFast`):
+#             The tokenizer used for encoding the data.
+#         mlm_probability (:obj:`float`, `optional`, defaults to 0.15):
+#             The probability with which to (randomly) mask tokens in the input.
+
+#     .. note::
+
+#         For best performance, this data collator should be used with a dataset having items that are dictionaries or
+#         BatchEncoding, with the :obj:`"special_tokens_mask"` key, as returned by a
+#         :class:`~transformers.PreTrainedTokenizer` or a :class:`~transformers.PreTrainedTokenizerFast` with the
+#         argument :obj:`return_special_tokens_mask=True`.
+#     """
+
+#     tokenizer: PreTrainedTokenizerBase
+#     mlm_probability: float = 0.15
+
+#     def __post_init__(self):
+#         if self.tokenizer.mask_token is None:
+#             raise ValueError(
+#                 "This tokenizer does not have a mask token which is necessary for masked language modeling. "
+#                 "You should pass `mlm=False` to train on causal language modeling instead."
+#             )
+
+#     def __call__(self, examples: List[Dict[str, np.ndarray]], pad_to_multiple_of: int) -> Dict[str, np.ndarray]:
+#         # Handle dict or lists with proper padding and conversion to tensor.
+#         batch = self.tokenizer.pad(examples, pad_to_multiple_of=pad_to_multiple_of, return_tensors=TensorType.NUMPY)
+
+#         # If special token mask has been preprocessed, pop it from the dict.
+#         special_tokens_mask = batch.pop("special_tokens_mask", None)
+
+#         batch["input_ids"], batch["labels"] = self.mask_tokens(
+#             batch["input_ids"], special_tokens_mask=special_tokens_mask
+#         )
+#         return batch
+
+#     def mask_tokens(
+#         self, inputs: np.ndarray, special_tokens_mask: Optional[np.ndarray]
+#     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
+#         """
+#         Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
+#         """
+#         labels = inputs.copy()
+#         # We sample a few tokens in each sequence for MLM training (with probability `self.mlm_probability`)
+#         probability_matrix = np.full(labels.shape, self.mlm_probability)
+#         special_tokens_mask = special_tokens_mask.astype("bool")
+
+#         probability_matrix[special_tokens_mask] = 0.0
+#         masked_indices = np.random.binomial(1, probability_matrix).astype("bool")
+#         labels[~masked_indices] = -100  # We only compute loss on masked tokens
+
+#         # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
+#         indices_replaced = np.random.binomial(1, np.full(labels.shape, 0.8)).astype("bool") & masked_indices
+#         inputs[indices_replaced] = self.tokenizer.convert_tokens_to_ids(self.tokenizer.mask_token)
+
+#         # 10% of the time, we replace masked input tokens with random word
+#         indices_random = np.random.binomial(1, np.full(labels.shape, 0.5)).astype("bool")
+#         indices_random &= masked_indices & ~indices_replaced
+
+#         random_words = np.random.randint(self.tokenizer.vocab_size, size=labels.shape, dtype="i4")
+#         inputs[indices_random] = random_words[indices_random]
+
+#         # The rest of the time (10% of the time) we keep the masked input tokens unchanged
+#         return inputs, labels
+
+
+# # def data_loader(rng: jax.random.PRNGKey, dataset: Dataset, batch_size: int, shuffle: bool = False):
+# #     """
+# #     Returns batches of size `batch_size` from truncated `dataset`, sharded over all local devices.
+# #     Shuffle batches if `shuffle` is `True`.
+# #     """
+# #     steps_per_epoch = len(dataset) // batch_size
+
+# #     if shuffle:
+# #         batch_idx = jax.random.permutation(rng, len(dataset))
+# #     else:
+# #         batch_idx = jnp.arange(len(dataset))
+
+# #     batch_idx = batch_idx[: steps_per_epoch * batch_size]  # Skip incomplete batch.
+# #     batch_idx = batch_idx.reshape((steps_per_epoch, batch_size))
+
+# #     for idx in batch_idx:
+# #         batch = dataset[idx]
+# #         batch = {k: jnp.array(v) for k, v in batch.items()}
+
+# #         batch = shard(batch)
+
+# #         yield batch
+
+# def generate_batch_splits(samples_idx: jnp.ndarray, batch_size: int) -> jnp.ndarray:
+#     num_samples = len(samples_idx)
+#     samples_to_remove = num_samples % batch_size
+
+#     if samples_to_remove != 0:
+#         samples_idx = samples_idx[:-samples_to_remove]
+#     sections_split = num_samples // batch_size
+#     batch_idx = np.split(samples_idx, sections_split)
+#     return batch_idx
+
+
+# def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
+#     summary_writer.scalar("train_time", train_time, step)
+
+#     train_metrics = get_metrics(train_metrics)
+#     for key, vals in train_metrics.items():
+#         tag = f"train_{key}"
+#         for i, val in enumerate(vals):
+#             summary_writer.scalar(tag, val, step - len(vals) + i + 1)
+
+#     for metric_name, value in eval_metrics.items():
+#         summary_writer.scalar(f"eval_{metric_name}", value, step)
+
+
+# if __name__ == "__main__":
+#     # See all possible arguments in src/transformers/training_args.py
+#     # or by passing the --help flag to this script.
+#     # We now keep distinct sets of args, for a cleaner separation of concerns.
+
+#     parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments))
+#     if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+#         # If we pass only one argument to the script and it's the path to a json file,
+#         # let's parse it to get our arguments.
+#         model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
+#     else:
+#         model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+
+#     if (
+#         os.path.exists(training_args.output_dir)
+#         and os.listdir(training_args.output_dir)
+#         and training_args.do_train
+#         and not training_args.overwrite_output_dir
+#     ):
+#         raise ValueError(
+#             f"Output directory ({training_args.output_dir}) already exists and is not empty."
+#             "Use --overwrite_output_dir to overcome."
+#         )
+
+#     # TODO: Fix/remove logging
+#     # # Setup logging
+#     # logging.basicConfig(
+#     #     format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+#     #     level="NOTSET",
+#     #     datefmt="[%X]",
+#     # )
+
+#     # # Log on each process the small summary:
+#     # logger = logging.getLogger(__name__)
+#     # logger.warning(
+#     #     f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+#     #     + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+#     # )
+
+#     # Set the verbosity to info of the Transformers logger (on main process only):
+#     # logger.info(f"Training/evaluation parameters {training_args}")
+
+#     # Set seed before initializing model.
+#     set_seed(training_args.seed)
+
+#     # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
+#     # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
+#     # (the dataset will be downloaded automatically from the datasets Hub).
+#     #
+#     # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
+#     # 'text' is found. You can easily tweak this behavior (see below).
+#     #
+#     # In distributed training, the load_dataset function guarantees that only one local process can concurrently
+#     # download the dataset.
+#     if data_args.dataset_name is not None:
+#         # Downloading and loading a dataset from the hub.
+#         datasets = load_dataset(data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir)
+
+#         if "validation" not in datasets.keys():
+#             datasets["validation"] = load_dataset(
+#                 data_args.dataset_name,
+#                 data_args.dataset_config_name,
+#                 split=f"train[:{data_args.validation_split_percentage}%]",
+#                 cache_dir=model_args.cache_dir,
+#             )
+#             datasets["train"] = load_dataset(
+#                 data_args.dataset_name,
+#                 data_args.dataset_config_name,
+#                 split=f"train[{data_args.validation_split_percentage}%:]",
+#                 cache_dir=model_args.cache_dir,
+#             )
+#     else:
+#         data_files = {}
+#         if data_args.train_file is not None:
+#             data_files["train"] = data_args.train_file
+#         if data_args.validation_file is not None:
+#             data_files["validation"] = data_args.validation_file
+#         extension = data_args.train_file.split(".")[-1]
+#         if extension == "txt":
+#             extension = "text"
+#         datasets = load_dataset(extension, data_files=data_files, cache_dir=model_args.cache_dir)
+#     # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
+#     # https://huggingface.co/docs/datasets/loading_datasets.html.
+
+#     # Load pretrained model and tokenizer
+
+#     # TODO: Leverage AutoConfig
+#     # Distributed training:
+#     # The .from_pretrained methods guarantee that only one local process can concurrently
+#     # download model & vocab.
+#     # if model_args.config_name:
+#     #     config = AutoConfig.from_pretrained(model_args.config_name, cache_dir=model_args.cache_dir)
+#     # elif model_args.model_name_or_path:
+#     #     config = AutoConfig.from_pretrained(model_args.model_name_or_path, cache_dir=model_args.cache_dir)
+#     # else:
+#     #     config = CONFIG_MAPPING[model_args.model_type]()
+#     #     logger.warning("You are instantiating a new config instance from scratch.")
+
+#     # TODO: Leverage AutoConfig
+#     config = RotoBARTConfig(
+#       encoder_layers=ModelArguments.encoder_layers,
+#       encoder_ffn_dim=ModelArguments.encoder_ffn_dim, 
+#       decoder_layers=ModelArguments.decoder_layers, 
+#       decoder_ffn_dim=ModelArguments.decoder_ffn_dim
+#     )
+
+#     # TODO: Load model from config
+#     #model = FlaxAutoModelForMaskedLM.from_config(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
+#     model = FlaxRotoBARTForConditionalGeneration(config=config)
+
+
+#     # TODO: leverage AutoTokenizer
+#     if model_args.tokenizer_name:
+#         tokenizer = AutoTokenizer.from_pretrained(
+#             model_args.tokenizer_name, cache_dir=model_args.cache_dir, use_fast=model_args.use_fast_tokenizer
+#         )
+#     # elif model_args.model_name_or_path:
+#     #     tokenizer = AutoTokenizer.from_pretrained(
+#     #         model_args.model_name_or_path, cache_dir=model_args.cache_dir, use_fast=model_args.use_fast_tokenizer
+#     #     )
+#     # else:
+#     #     raise ValueError(
+#     #         "You are instantiating a new tokenizer from scratch. This is not supported by this script."
+#     #         "You can do it from another script, save it, and load it from here, using --tokenizer_name."
+#     #     )
+
+#     # Preprocessing the datasets.
+#     # First we tokenize all the texts.
+#     if training_args.do_train:
+#         column_names = datasets["train"].column_names
+#     else:
+#         column_names = datasets["validation"].column_names
+#     text_column_name = "text" if "text" in column_names else column_names[0]
+
+#     max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
+
+#     if data_args.line_by_line:
+#         # When using line_by_line, we just tokenize each nonempty line.
+#         padding = "max_length" if data_args.pad_to_max_length else False
+
+#         def tokenize_function(examples):
+#             # Remove empty lines
+#             examples = [line for line in examples if len(line) > 0 and not line.isspace()]
+#             return tokenizer(
+#                 examples,
+#                 return_special_tokens_mask=True,
+#                 padding=padding,
+#                 truncation=True,
+#                 max_length=max_seq_length,
+#             )
+
+#         tokenized_datasets = datasets.map(
+#             tokenize_function,
+#             input_columns=[text_column_name],
+#             batched=True,
+#             num_proc=data_args.preprocessing_num_workers,
+#             remove_columns=column_names,
+#             load_from_cache_file=not data_args.overwrite_cache,
+#         )
+
+#     else:
+#         # Otherwise, we tokenize every text, then concatenate them together before splitting them in smaller parts.
+#         # We use `return_special_tokens_mask=True` because DataCollatorForLanguageModeling (see below) is more
+#         # efficient when it receives the `special_tokens_mask`.
+#         def tokenize_function(examples):
+#             return tokenizer(examples[text_column_name], return_special_tokens_mask=True)
+
+#         tokenized_datasets = datasets.map(
+#             tokenize_function,
+#             batched=True,
+#             num_proc=data_args.preprocessing_num_workers,
+#             remove_columns=column_names,
+#             load_from_cache_file=not data_args.overwrite_cache,
+#         )
+
+#         # Main data processing function that will concatenate all texts from our dataset and generate chunks of
+#         # max_seq_length.
+#         def group_texts(examples):
+#             # Concatenate all texts.
+#             concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
+#             total_length = len(concatenated_examples[list(examples.keys())[0]])
+#             # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
+#             # customize this part to your needs.
+#             total_length = (total_length // max_seq_length) * max_seq_length
+#             # Split by chunks of max_len.
+#             result = {
+#                 k: [t[i : i + max_seq_length] for i in range(0, total_length, max_seq_length)]
+#                 for k, t in concatenated_examples.items()
+#             }
+#             return result
+
+#         # Note that with `batched=True`, this map processes 1,000 texts together, so group_texts throws away a
+#         # remainder for each of those groups of 1,000 texts. You can adjust that batch_size here but a higher value
+#         # might be slower to preprocess.
+#         #
+#         # To speed up this part, we use multiprocessing. See the documentation of the map method for more information:
+#         # https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.map
+#         tokenized_datasets = tokenized_datasets.map(
+#             group_texts,
+#             batched=True,
+#             num_proc=data_args.preprocessing_num_workers,
+#             load_from_cache_file=not data_args.overwrite_cache,
+#         )
+
+#     # Enable tensorboard only on the master node
+#     if has_tensorboard and jax.process_index() == 0:
+#         summary_writer = SummaryWriter(log_dir=Path(training_args.output_dir))
+
+#     # Data collator
+#     # This one will take care of randomly masking the tokens.
+#     data_collator = FlaxDataCollatorForLanguageModeling(tokenizer=tokenizer, mlm_probability=data_args.mlm_probability)
+
+#     # Initialize our training
+#     rng = jax.random.PRNGKey(training_args.seed)
+#     dropout_rngs = jax.random.split(rng, jax.local_device_count())
+
+#     # TODO: Load model from config
+#     #model = FlaxAutoModelForMaskedLM.from_config(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
+#     model = FlaxRotoBARTForConditionalGeneration(config=config)
+
+#     # Store some constant
+#     num_epochs = int(training_args.num_train_epochs)
+#     train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
+#     eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
+
+#     num_train_steps = len(tokenized_datasets["train"]) // train_batch_size * num_epochs
+
+#     # Create learning rate schedule
+#     warmup_fn = optax.linear_schedule(
+#         init_value=0.0, end_value=training_args.learning_rate, transition_steps=training_args.warmup_steps
+#     )
+#     decay_fn = optax.linear_schedule(
+#         init_value=training_args.learning_rate,
+#         end_value=0,
+#         transition_steps=num_train_steps - training_args.warmup_steps,
+#     )
+#     linear_decay_lr_schedule_fn = optax.join_schedules(
+#         schedules=[warmup_fn, decay_fn], boundaries=[training_args.warmup_steps]
+#     )
+
+#     # We use Optax's "masking" functionality to not apply weight decay
+#     # to bias and LayerNorm scale parameters. decay_mask_fn returns a
+#     # mask boolean with the same structure as the parameters.
+#     # The mask is True for parameters that should be decayed.
+#     # Note that this mask is specifically adapted for FlaxBERT-like models.
+#     # For other models, one should correct the layer norm parameter naming
+#     # accordingly.
+#     def decay_mask_fn(params):
+#         flat_params = traverse_util.flatten_dict(params)
+#         flat_mask = {path: (path[-1] != "bias" and path[-2:] != ("LayerNorm", "scale")) for path in flat_params}
+#         return traverse_util.unflatten_dict(flat_mask)
+
+#     # create adam optimizer
+#     adamw = optax.adamw(
+#         learning_rate=linear_decay_lr_schedule_fn,
+#         b1=training_args.adam_beta1,
+#         b2=training_args.adam_beta2,
+#         eps=1e-8,
+#         weight_decay=training_args.weight_decay,
+#         mask=decay_mask_fn,
+#     )
+
+#     # Setup train state
+#     state = train_state.TrainState.create(apply_fn=model.__call__, params=model.params, tx=adamw)
+
+#     # Define gradient update step fn
+#     def train_step(state, batch, dropout_rng):
+#         dropout_rng, new_dropout_rng = jax.random.split(dropout_rng)
+
+#         def loss_fn(params):
+#             labels = batch.pop("labels")
+
+#             logits = state.apply_fn(**batch, params=params, dropout_rng=dropout_rng, train=True)[0]
+
+#             # compute loss, ignore padded input tokens
+#             label_mask = jnp.where(labels > 0, 1.0, 0.0)
+#             loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])) * label_mask
+
+#             # take average
+#             loss = loss.sum() / label_mask.sum()
+
+#             return loss
+
+#         grad_fn = jax.value_and_grad(loss_fn)
+#         loss, grad = grad_fn(state.params)
+#         grad = jax.lax.pmean(grad, "batch")
+#         new_state = state.apply_gradients(grads=grad)
+
+#         metrics = jax.lax.pmean(
+#             {"loss": loss, "learning_rate": linear_decay_lr_schedule_fn(state.step)}, axis_name="batch"
+#         )
+
+#         return new_state, metrics, new_dropout_rng
+
+#     # Create parallel version of the train step
+#     p_train_step = jax.pmap(train_step, "batch", donate_argnums=(0,))
+
+#     # Define eval fn
+#     def eval_step(params, batch):
+#         labels = batch.pop("labels")
+
+#         logits = model(**batch, params=params, train=False)[0]
+
+#         # compute loss, ignore padded input tokens
+#         label_mask = jnp.where(labels > 0, 1.0, 0.0)
+#         loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])) * label_mask
+
+#         # compute accuracy
+#         accuracy = jnp.equal(jnp.argmax(logits, axis=-1), labels) * label_mask
+
+#         # summarize metrics
+#         metrics = {"loss": loss.sum(), "accuracy": accuracy.sum(), "normalizer": label_mask.sum()}
+#         metrics = jax.lax.psum(metrics, axis_name="batch")
+
+#         return metrics
+
+#     p_eval_step = jax.pmap(eval_step, "batch", donate_argnums=(0,))
+
+#     # Replicate the train state on each device
+#     state = jax_utils.replicate(state)
+
+#     train_time = 0
+#     epochs = tqdm(range(num_epochs), desc=f"Epoch ... (1/{num_epochs})", position=0)
+#     for epoch in epochs:
+#         # ======================== Training ================================
+#         train_start = time.time()
+#         train_metrics = []
+
+#         # Create sampling rng
+#         rng, input_rng = jax.random.split(rng)
+
+#         # Generate an epoch by shuffling sampling indices from the train dataset
+#         num_train_samples = len(tokenized_datasets["train"])
+#         train_samples_idx = jax.random.permutation(input_rng, jnp.arange(num_train_samples))
+#         train_batch_idx = generate_batch_splits(train_samples_idx, train_batch_size)
+
+#         # Gather the indexes for creating the batch and do a training step
+#         for i, batch_idx in enumerate(tqdm(train_batch_idx, desc="Training...", position=1)):
+#             samples = [tokenized_datasets["train"][int(idx)] for idx in batch_idx]
+#             model_inputs = data_collator(samples, pad_to_multiple_of=16)
+
+#             # Model forward
+#             model_inputs = shard(model_inputs.data)
+#             state, train_metric, dropout_rngs = p_train_step(state, model_inputs, dropout_rngs)
+#             train_metrics.append(train_metric)
+
+#         train_time += time.time() - train_start
+
+#         print(f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})")
+
+#         epochs.write(
+#             f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})"
+#         )
+
+#         # ======================== Evaluating ==============================
+#         num_eval_samples = len(tokenized_datasets["validation"])
+#         eval_samples_idx = jnp.arange(num_eval_samples)
+#         eval_batch_idx = generate_batch_splits(eval_samples_idx, eval_batch_size)
+
+#         eval_metrics = []
+#         for i, batch_idx in enumerate(tqdm(eval_batch_idx, desc="Evaluating ...", position=2)):
+#             samples = [tokenized_datasets["validation"][int(idx)] for idx in batch_idx]
+#             model_inputs = data_collator(samples, pad_to_multiple_of=16)
+
+#             # Model forward
+#             model_inputs = shard(model_inputs.data)
+#             metrics = p_eval_step(state.params, model_inputs)
+#             eval_metrics.append(metrics)
+
+#         # normalize eval metrics
+#         eval_metrics = get_metrics(eval_metrics)
+#         eval_metrics = jax.tree_map(jnp.sum, eval_metrics)
+#         eval_normalizer = eval_metrics.pop("normalizer")
+#         eval_metrics = jax.tree_map(lambda x: x / eval_normalizer, eval_metrics)
+
+#         # Update progress bar
+#         epochs.desc = (
+#             f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {eval_metrics['loss']}, Acc: {eval_metrics['accuracy']})"
+#         )
+
+#         # Save metrics
+#         if has_tensorboard and jax.process_index() == 0:
+#             cur_step = epoch * (len(tokenized_datasets["train"]) // train_batch_size)
+#             write_metric(summary_writer, train_metrics, eval_metrics, train_time, cur_step)
+
+#         # save checkpoint after each epoch and push checkpoint to the hub
+#         if jax.process_index() == 0:
+#             params = jax.device_get(jax.tree_map(lambda x: x[0], state.params))
+#             model.save_pretrained(
+#                 training_args.output_dir,
+#                 params=params,
+#                 push_to_hub=training_args.push_to_hub,
+#                 commit_message=f"Saving weights and logs of epoch {epoch+1}",
+#             )

--- a/run_dnlm_flax.py
+++ b/run_dnlm_flax.py
@@ -1,0 +1,723 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2021 The HuggingFace Team All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Fine-tuning the library models for masked language modeling (BERT, ALBERT, RoBERTa...) with whole word masking on a
+text file or a dataset.
+
+Here is the full list of checkpoints on the hub that can be fine-tuned by this script:
+https://huggingface.co/models?filter=masked-lm
+"""
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+
+# You can also adapt this script on your own masked language modeling task. Pointers for this are left as comments.
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from datasets import load_dataset
+from tqdm import tqdm
+
+import flax
+import jax
+import jax.numpy as jnp
+import optax
+from flax import jax_utils, traverse_util
+from flax.training import train_state
+from flax.training.common_utils import get_metrics, onehot, shard
+from transformers import (
+    CONFIG_MAPPING,
+    FLAX_MODEL_FOR_MASKED_LM_MAPPING,
+    AutoConfig,
+    AutoTokenizer,
+    FlaxAutoModelForMaskedLM,
+    HfArgumentParser,
+    PreTrainedTokenizerBase,
+    TensorType,
+    TrainingArguments,
+    is_tensorboard_available,
+    set_seed,
+)
+
+
+from modeling_flax_rotobart import *
+from configuration_rotobart import *
+from transformers import BartTokenizer
+
+
+# Cache the result
+has_tensorboard = is_tensorboard_available()
+if has_tensorboard:
+    try:
+        from flax.metrics.tensorboard import SummaryWriter
+    except ImportError as ie:
+        has_tensorboard = False
+        print(f"Unable to display metrics through TensorBoard because some package are not installed: {ie}")
+
+else:
+    print(
+        "Unable to display metrics through TensorBoard because the package is not installed: "
+        "Please run pip install tensorboard to enable."
+    )
+
+
+MODEL_CONFIG_CLASSES = list(FLAX_MODEL_FOR_MASKED_LM_MAPPING.keys())
+MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
+
+
+@dataclass
+class ModelArguments:
+    """
+    Arguments pertaining to which model/config/tokenizer we are going to fine-tune, or train from scratch.
+    """
+
+    model_name_or_path: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "The model checkpoint for weights initialization."
+            "Don't set if you want to train a model from scratch."
+        },
+    )
+    model_type: Optional[str] = field(
+        default=None,
+        metadata={"help": "If training from scratch, pass a model type from the list: " + ", ".join(MODEL_TYPES)},
+    )
+    config_name: Optional[str] = field(
+        default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
+    )
+    tokenizer_name: Optional[str] = field(
+        default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
+    )
+    cache_dir: Optional[str] = field(
+        default=None, metadata={"help": "Where do you want to store the pretrained models downloaded from s3"}
+    )
+    use_fast_tokenizer: bool = field(
+        default=True,
+        metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
+    )
+    dtype: Optional[str] = field(
+        default="float32",
+        metadata={
+            "help": "Floating-point format in which the model weights should be initialized and trained. Choose one of `[float32, float16, bfloat16]`."
+        },
+    )
+    encoder_layers: Optional[int] = field(
+        default=2,
+        metadata={
+            "help": "Number of encoder layers"
+        },
+    )
+    decoder_layers: Optional[int] = field(
+        default=2,
+        metadata={
+            "help": "Number of decoder layers"
+        },
+    )
+    encoder_ffn_dim: Optional[int] = field(
+        default=256,
+        metadata={
+            "help": "Dimension of encoder feedforward network"
+        },
+    )
+    decoder_ffn_dim: Optional[int] = field(
+        default=256,
+        metadata={
+            "help": "Dimension of decoder feedforward network"
+        },
+    )
+
+
+@dataclass
+class DataTrainingArguments:
+    """
+    Arguments pertaining to what data we are going to input our model for training and eval.
+    """
+
+    dataset_name: Optional[str] = field(
+        default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
+    )
+    dataset_config_name: Optional[str] = field(
+        default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+    )
+    train_file: Optional[str] = field(default=None, metadata={"help": "The input training data file (a text file)."})
+    validation_file: Optional[str] = field(
+        default=None,
+        metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
+    )
+    train_ref_file: Optional[str] = field(
+        default=None,
+        metadata={"help": "An optional input train ref data file for whole word masking in Chinese."},
+    )
+    validation_ref_file: Optional[str] = field(
+        default=None,
+        metadata={"help": "An optional input validation ref data file for whole word masking in Chinese."},
+    )
+    overwrite_cache: bool = field(
+        default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
+    )
+    validation_split_percentage: Optional[int] = field(
+        default=5,
+        metadata={
+            "help": "The percentage of the train set used as validation set in case there's no validation split"
+        },
+    )
+    max_seq_length: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "The maximum total input sequence length after tokenization. Sequences longer "
+            "than this will be truncated. Default to the max input length of the model."
+        },
+    )
+    preprocessing_num_workers: Optional[int] = field(
+        default=None,
+        metadata={"help": "The number of processes to use for the preprocessing."},
+    )
+    mlm_probability: float = field(
+        default=0.15, metadata={"help": "Ratio of tokens to mask for masked language modeling loss"}
+    )
+    pad_to_max_length: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to pad all samples to `max_seq_length`. "
+            "If False, will pad the samples dynamically when batching to the maximum length in the batch."
+        },
+    )
+    line_by_line: bool = field(
+        default=False,
+        metadata={"help": "Whether distinct lines of text in the dataset are to be handled as distinct sequences."},
+    )
+
+    def __post_init__(self):
+        if self.dataset_name is None and self.train_file is None and self.validation_file is None:
+            raise ValueError("Need either a dataset name or a training/validation file.")
+        else:
+            if self.train_file is not None:
+                extension = self.train_file.split(".")[-1]
+                assert extension in ["csv", "json", "txt"], "`train_file` should be a csv, a json or a txt file."
+            if self.validation_file is not None:
+                extension = self.validation_file.split(".")[-1]
+                assert extension in ["csv", "json", "txt"], "`validation_file` should be a csv, a json or a txt file."
+
+
+@flax.struct.dataclass
+class FlaxDataCollatorForLanguageModeling:
+    """
+    Data collator used for language modeling. Inputs are dynamically padded to the maximum length of a batch if they
+    are not all of the same length.
+
+    Args:
+        tokenizer (:class:`~transformers.PreTrainedTokenizer` or :class:`~transformers.PreTrainedTokenizerFast`):
+            The tokenizer used for encoding the data.
+        mlm_probability (:obj:`float`, `optional`, defaults to 0.15):
+            The probability with which to (randomly) mask tokens in the input.
+
+    .. note::
+
+        For best performance, this data collator should be used with a dataset having items that are dictionaries or
+        BatchEncoding, with the :obj:`"special_tokens_mask"` key, as returned by a
+        :class:`~transformers.PreTrainedTokenizer` or a :class:`~transformers.PreTrainedTokenizerFast` with the
+        argument :obj:`return_special_tokens_mask=True`.
+    """
+
+    tokenizer: PreTrainedTokenizerBase
+    mlm_probability: float = 0.15
+
+    def __post_init__(self):
+        if self.tokenizer.mask_token is None:
+            raise ValueError(
+                "This tokenizer does not have a mask token which is necessary for masked language modeling. "
+                "You should pass `mlm=False` to train on causal language modeling instead."
+            )
+
+    def __call__(self, examples: List[Dict[str, np.ndarray]], pad_to_multiple_of: int) -> Dict[str, np.ndarray]:
+        # Handle dict or lists with proper padding and conversion to tensor.
+        batch = self.tokenizer.pad(examples, pad_to_multiple_of=pad_to_multiple_of, return_tensors=TensorType.NUMPY)
+
+        # If special token mask has been preprocessed, pop it from the dict.
+        special_tokens_mask = batch.pop("special_tokens_mask", None)
+
+        batch["input_ids"], batch["labels"] = self.mask_tokens(
+            batch["input_ids"], special_tokens_mask=special_tokens_mask
+        )
+        return batch
+
+    def mask_tokens(
+        self, inputs: np.ndarray, special_tokens_mask: Optional[np.ndarray]
+    ) -> Tuple[jnp.ndarray, jnp.ndarray]:
+        """
+        Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
+        """
+        labels = inputs.copy()
+        # We sample a few tokens in each sequence for MLM training (with probability `self.mlm_probability`)
+        probability_matrix = np.full(labels.shape, self.mlm_probability)
+        special_tokens_mask = special_tokens_mask.astype("bool")
+
+        probability_matrix[special_tokens_mask] = 0.0
+        masked_indices = np.random.binomial(1, probability_matrix).astype("bool")
+        labels[~masked_indices] = -100  # We only compute loss on masked tokens
+
+        # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
+        indices_replaced = np.random.binomial(1, np.full(labels.shape, 0.8)).astype("bool") & masked_indices
+        inputs[indices_replaced] = self.tokenizer.convert_tokens_to_ids(self.tokenizer.mask_token)
+
+        # 10% of the time, we replace masked input tokens with random word
+        indices_random = np.random.binomial(1, np.full(labels.shape, 0.5)).astype("bool")
+        indices_random &= masked_indices & ~indices_replaced
+
+        random_words = np.random.randint(self.tokenizer.vocab_size, size=labels.shape, dtype="i4")
+        inputs[indices_random] = random_words[indices_random]
+
+        # The rest of the time (10% of the time) we keep the masked input tokens unchanged
+        return inputs, labels
+
+
+# def data_loader(rng: jax.random.PRNGKey, dataset: Dataset, batch_size: int, shuffle: bool = False):
+#     """
+#     Returns batches of size `batch_size` from truncated `dataset`, sharded over all local devices.
+#     Shuffle batches if `shuffle` is `True`.
+#     """
+#     steps_per_epoch = len(dataset) // batch_size
+
+#     if shuffle:
+#         batch_idx = jax.random.permutation(rng, len(dataset))
+#     else:
+#         batch_idx = jnp.arange(len(dataset))
+
+#     batch_idx = batch_idx[: steps_per_epoch * batch_size]  # Skip incomplete batch.
+#     batch_idx = batch_idx.reshape((steps_per_epoch, batch_size))
+
+#     for idx in batch_idx:
+#         batch = dataset[idx]
+#         batch = {k: jnp.array(v) for k, v in batch.items()}
+
+#         batch = shard(batch)
+
+#         yield batch
+
+def generate_batch_splits(samples_idx: jnp.ndarray, batch_size: int) -> jnp.ndarray:
+    num_samples = len(samples_idx)
+    samples_to_remove = num_samples % batch_size
+
+    if samples_to_remove != 0:
+        samples_idx = samples_idx[:-samples_to_remove]
+    sections_split = num_samples // batch_size
+    batch_idx = np.split(samples_idx, sections_split)
+    return batch_idx
+
+
+def write_metric(summary_writer, train_metrics, eval_metrics, train_time, step):
+    summary_writer.scalar("train_time", train_time, step)
+
+    train_metrics = get_metrics(train_metrics)
+    for key, vals in train_metrics.items():
+        tag = f"train_{key}"
+        for i, val in enumerate(vals):
+            summary_writer.scalar(tag, val, step - len(vals) + i + 1)
+
+    for metric_name, value in eval_metrics.items():
+        summary_writer.scalar(f"eval_{metric_name}", value, step)
+
+
+if __name__ == "__main__":
+    # See all possible arguments in src/transformers/training_args.py
+    # or by passing the --help flag to this script.
+    # We now keep distinct sets of args, for a cleaner separation of concerns.
+
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments))
+    if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+        # If we pass only one argument to the script and it's the path to a json file,
+        # let's parse it to get our arguments.
+        model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
+    else:
+        model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+
+    if (
+        os.path.exists(training_args.output_dir)
+        and os.listdir(training_args.output_dir)
+        and training_args.do_train
+        and not training_args.overwrite_output_dir
+    ):
+        raise ValueError(
+            f"Output directory ({training_args.output_dir}) already exists and is not empty."
+            "Use --overwrite_output_dir to overcome."
+        )
+
+    # TODO: Fix/remove logging
+    # # Setup logging
+    # logging.basicConfig(
+    #     format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    #     level="NOTSET",
+    #     datefmt="[%X]",
+    # )
+
+    # # Log on each process the small summary:
+    # logger = logging.getLogger(__name__)
+    # logger.warning(
+    #     f"Process rank: {training_args.local_rank}, device: {training_args.device}, n_gpu: {training_args.n_gpu}"
+    #     + f"distributed training: {bool(training_args.local_rank != -1)}, 16-bits training: {training_args.fp16}"
+    # )
+
+    # Set the verbosity to info of the Transformers logger (on main process only):
+    # logger.info(f"Training/evaluation parameters {training_args}")
+
+    # Set seed before initializing model.
+    set_seed(training_args.seed)
+
+    # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
+    # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
+    # (the dataset will be downloaded automatically from the datasets Hub).
+    #
+    # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
+    # 'text' is found. You can easily tweak this behavior (see below).
+    #
+    # In distributed training, the load_dataset function guarantees that only one local process can concurrently
+    # download the dataset.
+    if data_args.dataset_name is not None:
+        # Downloading and loading a dataset from the hub.
+        datasets = load_dataset(data_args.dataset_name, data_args.dataset_config_name, cache_dir=model_args.cache_dir)
+
+        if "validation" not in datasets.keys():
+            datasets["validation"] = load_dataset(
+                data_args.dataset_name,
+                data_args.dataset_config_name,
+                split=f"train[:{data_args.validation_split_percentage}%]",
+                cache_dir=model_args.cache_dir,
+            )
+            datasets["train"] = load_dataset(
+                data_args.dataset_name,
+                data_args.dataset_config_name,
+                split=f"train[{data_args.validation_split_percentage}%:]",
+                cache_dir=model_args.cache_dir,
+            )
+    else:
+        data_files = {}
+        if data_args.train_file is not None:
+            data_files["train"] = data_args.train_file
+        if data_args.validation_file is not None:
+            data_files["validation"] = data_args.validation_file
+        extension = data_args.train_file.split(".")[-1]
+        if extension == "txt":
+            extension = "text"
+        datasets = load_dataset(extension, data_files=data_files, cache_dir=model_args.cache_dir)
+    # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
+    # https://huggingface.co/docs/datasets/loading_datasets.html.
+
+    # Load pretrained model and tokenizer
+
+    # TODO: Leverage AutoConfig
+    # Distributed training:
+    # The .from_pretrained methods guarantee that only one local process can concurrently
+    # download model & vocab.
+    # if model_args.config_name:
+    #     config = AutoConfig.from_pretrained(model_args.config_name, cache_dir=model_args.cache_dir)
+    # elif model_args.model_name_or_path:
+    #     config = AutoConfig.from_pretrained(model_args.model_name_or_path, cache_dir=model_args.cache_dir)
+    # else:
+    #     config = CONFIG_MAPPING[model_args.model_type]()
+    #     logger.warning("You are instantiating a new config instance from scratch.")
+
+    # TODO: Leverage AutoConfig
+    config = RotoBARTConfig(
+      encoder_layers=ModelArguments.encoder_layers,
+      encoder_ffn_dim=ModelArguments.encoder_ffn_dim, 
+      decoder_layers=ModelArguments.decoder_layers, 
+      decoder_ffn_dim=ModelArguments.decoder_ffn_dim
+    )
+
+    # TODO: leverage AutoTokenizer
+    if model_args.tokenizer_name:
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_args.tokenizer_name, cache_dir=model_args.cache_dir, use_fast=model_args.use_fast_tokenizer
+        )
+    # elif model_args.model_name_or_path:
+    #     tokenizer = AutoTokenizer.from_pretrained(
+    #         model_args.model_name_or_path, cache_dir=model_args.cache_dir, use_fast=model_args.use_fast_tokenizer
+    #     )
+    # else:
+    #     raise ValueError(
+    #         "You are instantiating a new tokenizer from scratch. This is not supported by this script."
+    #         "You can do it from another script, save it, and load it from here, using --tokenizer_name."
+    #     )
+
+    # Preprocessing the datasets.
+    # First we tokenize all the texts.
+    if training_args.do_train:
+        column_names = datasets["train"].column_names
+    else:
+        column_names = datasets["validation"].column_names
+    text_column_name = "text" if "text" in column_names else column_names[0]
+
+    max_seq_length = min(data_args.max_seq_length, tokenizer.model_max_length)
+
+    if data_args.line_by_line:
+        # When using line_by_line, we just tokenize each nonempty line.
+        padding = "max_length" if data_args.pad_to_max_length else False
+
+        def tokenize_function(examples):
+            # Remove empty lines
+            examples = [line for line in examples if len(line) > 0 and not line.isspace()]
+            return tokenizer(
+                examples,
+                return_special_tokens_mask=True,
+                padding=padding,
+                truncation=True,
+                max_length=max_seq_length,
+            )
+
+        tokenized_datasets = datasets.map(
+            tokenize_function,
+            input_columns=[text_column_name],
+            batched=True,
+            num_proc=data_args.preprocessing_num_workers,
+            remove_columns=column_names,
+            load_from_cache_file=not data_args.overwrite_cache,
+        )
+
+    else:
+        # Otherwise, we tokenize every text, then concatenate them together before splitting them in smaller parts.
+        # We use `return_special_tokens_mask=True` because DataCollatorForLanguageModeling (see below) is more
+        # efficient when it receives the `special_tokens_mask`.
+        def tokenize_function(examples):
+            return tokenizer(examples[text_column_name], return_special_tokens_mask=True)
+
+        tokenized_datasets = datasets.map(
+            tokenize_function,
+            batched=True,
+            num_proc=data_args.preprocessing_num_workers,
+            remove_columns=column_names,
+            load_from_cache_file=not data_args.overwrite_cache,
+        )
+
+        # Main data processing function that will concatenate all texts from our dataset and generate chunks of
+        # max_seq_length.
+        def group_texts(examples):
+            # Concatenate all texts.
+            concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
+            total_length = len(concatenated_examples[list(examples.keys())[0]])
+            # We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
+            # customize this part to your needs.
+            total_length = (total_length // max_seq_length) * max_seq_length
+            # Split by chunks of max_len.
+            result = {
+                k: [t[i : i + max_seq_length] for i in range(0, total_length, max_seq_length)]
+                for k, t in concatenated_examples.items()
+            }
+            return result
+
+        # Note that with `batched=True`, this map processes 1,000 texts together, so group_texts throws away a
+        # remainder for each of those groups of 1,000 texts. You can adjust that batch_size here but a higher value
+        # might be slower to preprocess.
+        #
+        # To speed up this part, we use multiprocessing. See the documentation of the map method for more information:
+        # https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.map
+        tokenized_datasets = tokenized_datasets.map(
+            group_texts,
+            batched=True,
+            num_proc=data_args.preprocessing_num_workers,
+            load_from_cache_file=not data_args.overwrite_cache,
+        )
+
+    # Enable tensorboard only on the master node
+    if has_tensorboard and jax.process_index() == 0:
+        summary_writer = SummaryWriter(log_dir=Path(training_args.output_dir))
+
+    # Data collator
+    # This one will take care of randomly masking the tokens.
+    data_collator = FlaxDataCollatorForLanguageModeling(tokenizer=tokenizer, mlm_probability=data_args.mlm_probability)
+
+    # Initialize our training
+    rng = jax.random.PRNGKey(training_args.seed)
+    dropout_rngs = jax.random.split(rng, jax.local_device_count())
+
+    # TODO: Load model from config
+    #model = FlaxAutoModelForMaskedLM.from_config(config, seed=training_args.seed, dtype=getattr(jnp, model_args.dtype))
+    model = FlaxRotoBARTForConditionalGeneration(config=config)
+
+    # Store some constant
+    num_epochs = int(training_args.num_train_epochs)
+    train_batch_size = int(training_args.per_device_train_batch_size) * jax.device_count()
+    eval_batch_size = int(training_args.per_device_eval_batch_size) * jax.device_count()
+
+    num_train_steps = len(tokenized_datasets["train"]) // train_batch_size * num_epochs
+
+    # Create learning rate schedule
+    warmup_fn = optax.linear_schedule(
+        init_value=0.0, end_value=training_args.learning_rate, transition_steps=training_args.warmup_steps
+    )
+    decay_fn = optax.linear_schedule(
+        init_value=training_args.learning_rate,
+        end_value=0,
+        transition_steps=num_train_steps - training_args.warmup_steps,
+    )
+    linear_decay_lr_schedule_fn = optax.join_schedules(
+        schedules=[warmup_fn, decay_fn], boundaries=[training_args.warmup_steps]
+    )
+
+    # We use Optax's "masking" functionality to not apply weight decay
+    # to bias and LayerNorm scale parameters. decay_mask_fn returns a
+    # mask boolean with the same structure as the parameters.
+    # The mask is True for parameters that should be decayed.
+    # Note that this mask is specifically adapted for FlaxBERT-like models.
+    # For other models, one should correct the layer norm parameter naming
+    # accordingly.
+    def decay_mask_fn(params):
+        flat_params = traverse_util.flatten_dict(params)
+        flat_mask = {path: (path[-1] != "bias" and path[-2:] != ("LayerNorm", "scale")) for path in flat_params}
+        return traverse_util.unflatten_dict(flat_mask)
+
+    # create adam optimizer
+    adamw = optax.adamw(
+        learning_rate=linear_decay_lr_schedule_fn,
+        b1=training_args.adam_beta1,
+        b2=training_args.adam_beta2,
+        eps=1e-8,
+        weight_decay=training_args.weight_decay,
+        mask=decay_mask_fn,
+    )
+
+    # Setup train state
+    state = train_state.TrainState.create(apply_fn=model.__call__, params=model.params, tx=adamw)
+
+    # Define gradient update step fn
+    def train_step(state, batch, dropout_rng):
+        dropout_rng, new_dropout_rng = jax.random.split(dropout_rng)
+
+        def loss_fn(params):
+            labels = batch.pop("labels")
+
+            logits = state.apply_fn(**batch, params=params, dropout_rng=dropout_rng, train=True)[0]
+
+            # compute loss, ignore padded input tokens
+            label_mask = jnp.where(labels > 0, 1.0, 0.0)
+            loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])) * label_mask
+
+            # take average
+            loss = loss.sum() / label_mask.sum()
+
+            return loss
+
+        grad_fn = jax.value_and_grad(loss_fn)
+        loss, grad = grad_fn(state.params)
+        grad = jax.lax.pmean(grad, "batch")
+        new_state = state.apply_gradients(grads=grad)
+
+        metrics = jax.lax.pmean(
+            {"loss": loss, "learning_rate": linear_decay_lr_schedule_fn(state.step)}, axis_name="batch"
+        )
+
+        return new_state, metrics, new_dropout_rng
+
+    # Create parallel version of the train step
+    p_train_step = jax.pmap(train_step, "batch", donate_argnums=(0,))
+
+    # Define eval fn
+    def eval_step(params, batch):
+        labels = batch.pop("labels")
+
+        logits = model(**batch, params=params, train=False)[0]
+
+        # compute loss, ignore padded input tokens
+        label_mask = jnp.where(labels > 0, 1.0, 0.0)
+        loss = optax.softmax_cross_entropy(logits, onehot(labels, logits.shape[-1])) * label_mask
+
+        # compute accuracy
+        accuracy = jnp.equal(jnp.argmax(logits, axis=-1), labels) * label_mask
+
+        # summarize metrics
+        metrics = {"loss": loss.sum(), "accuracy": accuracy.sum(), "normalizer": label_mask.sum()}
+        metrics = jax.lax.psum(metrics, axis_name="batch")
+
+        return metrics
+
+    p_eval_step = jax.pmap(eval_step, "batch", donate_argnums=(0,))
+
+    # Replicate the train state on each device
+    state = jax_utils.replicate(state)
+
+    train_time = 0
+    epochs = tqdm(range(num_epochs), desc=f"Epoch ... (1/{num_epochs})", position=0)
+    for epoch in epochs:
+        # ======================== Training ================================
+        train_start = time.time()
+        train_metrics = []
+
+        # Create sampling rng
+        rng, input_rng = jax.random.split(rng)
+
+        # Generate an epoch by shuffling sampling indices from the train dataset
+        num_train_samples = len(tokenized_datasets["train"])
+        train_samples_idx = jax.random.permutation(input_rng, jnp.arange(num_train_samples))
+        train_batch_idx = generate_batch_splits(train_samples_idx, train_batch_size)
+
+        # Gather the indexes for creating the batch and do a training step
+        for i, batch_idx in enumerate(tqdm(train_batch_idx, desc="Training...", position=1)):
+            samples = [tokenized_datasets["train"][int(idx)] for idx in batch_idx]
+            model_inputs = data_collator(samples, pad_to_multiple_of=16)
+
+            # Model forward
+            model_inputs = shard(model_inputs.data)
+            state, train_metric, dropout_rngs = p_train_step(state, model_inputs, dropout_rngs)
+            train_metrics.append(train_metric)
+
+        train_time += time.time() - train_start
+
+        epochs.write(
+            f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {train_metric['loss']}, Learning Rate: {train_metric['learning_rate']})"
+        )
+
+        # ======================== Evaluating ==============================
+        num_eval_samples = len(tokenized_datasets["validation"])
+        eval_samples_idx = jnp.arange(num_eval_samples)
+        eval_batch_idx = generate_batch_splits(eval_samples_idx, eval_batch_size)
+
+        eval_metrics = []
+        for i, batch_idx in enumerate(tqdm(eval_batch_idx, desc="Evaluating ...", position=2)):
+            samples = [tokenized_datasets["validation"][int(idx)] for idx in batch_idx]
+            model_inputs = data_collator(samples, pad_to_multiple_of=16)
+
+            # Model forward
+            model_inputs = shard(model_inputs.data)
+            metrics = p_eval_step(state.params, model_inputs)
+            eval_metrics.append(metrics)
+
+        # normalize eval metrics
+        eval_metrics = get_metrics(eval_metrics)
+        eval_metrics = jax.tree_map(jnp.sum, eval_metrics)
+        eval_normalizer = eval_metrics.pop("normalizer")
+        eval_metrics = jax.tree_map(lambda x: x / eval_normalizer, eval_metrics)
+
+        # Update progress bar
+        epochs.desc = (
+            f"Epoch... ({epoch + 1}/{num_epochs} | Loss: {eval_metrics['loss']}, Acc: {eval_metrics['accuracy']})"
+        )
+
+        # Save metrics
+        if has_tensorboard and jax.process_index() == 0:
+            cur_step = epoch * (len(tokenized_datasets["train"]) // train_batch_size)
+            write_metric(summary_writer, train_metrics, eval_metrics, train_time, cur_step)
+
+        # save checkpoint after each epoch and push checkpoint to the hub
+        if jax.process_index() == 0:
+            params = jax.device_get(jax.tree_map(lambda x: x[0], state.params))
+            model.save_pretrained(
+                training_args.output_dir,
+                params=params,
+                push_to_hub=training_args.push_to_hub,
+                commit_message=f"Saving weights and logs of epoch {epoch+1}",
+            )


### PR DESCRIPTION
Based on HF flax language modelling examples: https://github.com/huggingface/transformers/blob/master/examples/flax/language-modeling/run_mlm_flax.py

This adds:
- a fix for `fixed_pos_embedding` to use jax's version of einsum
- a first start of a train script, steps though training steps on Google colab
    - The train script uses `FlaxRotoBARTForConditionalGeneration`  and a dummy `DummyFlaxDataCollatorForRotoBARTMLM`
- Dataset streaming from The Pile 
- Improved batch iteration, based on [HF dataset streaming] example script (https://github.com/huggingface/transformers/blob/master/examples/research_projects/jax-projects/dataset-streaming/run_mlm_flax_stream.py)
 

## To Do
Lots to do:
- ~~Get it to work on TPU~~
- - ~~Look closer at `generate_batch_splits`~~
- ~~Look closer at `group_texts`~~
- add sentence permutation 
- add text infill 
- Test on our TPU VM 


Test with:
```
python rotobart/run_dnlm_flax.py \
  --output_dir . \
  --overwrite_output_dir \
  --model_name_or_path rotobart \
  --tokenizer_name facebook/bart-large-cnn \
  --shuffle_buffer_size 100_000 \
  --do_train --do_eval \
  --max_seq_length 1024 \
  --encoder_layers 2 \
  --decoder_layers 2 \
  --per_device_train_batch_size 2 \
  --per_device_eval_batch_size 2 \
  --num_train_steps 1000 \
  --logging_steps 8 \
  --eval_steps 1000 \
  --num_eval_samples 100 \
  --warmup_steps 30 \
  --learning_rate 1e-4 \
  --use_wandb \
  --testing --colab_tpu
```