### PR TITLE
Add setence permutation collator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 git+https://github.com/huggingface/datasets@master
+jsonlines
+zstandard
+aiohttp
+nltk

--- a/sentence_permutation.py
+++ b/sentence_permutation.py
@@ -1,0 +1,21 @@
+import random
+from dataclasses import dataclass
+from typing import Dict
+
+import nltk
+from nltk.tokenize.punkt import PunktSentenceTokenizer
+
+
+@dataclass
+class SentencePermutationDataCollator:
+    sentence_tokenizer: PunktSentenceTokenizer = nltk.data.load(
+        "tokenizers/punkt/english.pickle"
+    )
+    sentence_separator: str = " "
+
+    def __call__(self, example: Dict[str, str]) -> Dict[str, str]:
+        sentences = self.sentence_tokenizer.tokenize(example["text"])
+        random.shuffle(sentences)
+        permutated_text = self.sentence_separator.join(sentences)
+        example["permuated_text"] = permutated_text
+        return example


### PR DESCRIPTION
Let's put SetencePermutationDataCollator into `data_collator.py` later when #4 merged.

Here's the example to use:
```python
>>> from datasets import load_dataset
>>> from sentence_permutation import SentencePermutationDataCollator
>>> pile = load_dataset("./pile.py", streaming=True, split="test")
Using custom data configuration default
>>> permutation = SentencePermutationDataCollator()
>>> p_pile = pile.map(permutation)
>>> it = iter(p_pile)
>>> next(it)
Generate examples from: https://the-eye.eu/public/AI/pile/test.jsonl.zst
{'id': 0,
'text': 'Roman Catholic Diocese of Tambacounda\n\nThe Roman Catholic Diocese of Tambacounda () is a diocese located in the city of Tambacounda in the Ecclesiastical province of Dakar in Senegal.\n\nHistory\n August 13, 1970: Established as Apostolic Prefecture of Tambacounda from the Diocese of Kaolack and Diocese of Saint-Louis du Sénégal\n April 17, 1989: Promoted as Diocese of Tambacounda\n\nSpecial churches\n The cathedralis Cathédrale Marie Reine de l’Univers in Tambacounda, which is located in the Medina Coura neighborhood of the town.\n\nLeadership\n Bishops of Tambacounda (Roman rite)\n Bishop Jean-Noël Diouf (since 1989.04.17)\n Prefects Apostolic of Tambacounda (Roman rite)\n Fr. Clément Cailleau, C.S.Sp. (1970.08.13 – 1986.04.24)\n\nSee also\nRoman Catholicism in Senegal\n\nReferences\n\nExternal links\n GCatholic.org\n Catholic Hierarchy \n\nCategory:Roman Catholic dioceses in Senegal\nCategory:Tambacounda\nCategory:Christian organizations established in 1970\nCategory:Roman Catholic dioceses and prelatures established in the 20th century',
'pile_set_name': 'Wikipedia (en)',
'permuated_text': 'Leadership\n Bishops of Tambacounda (Roman rite)\n Bishop Jean-Noël Diouf (since 1989.04.17)\n Prefects Apostolic of Tambacounda (Roman rite) \n Fr. (1970.08.13 – 1986.04.24)\n\nSee also\nRoman Catholicism in Senegal\n\nReferences\n\nExternal links\n GCatholic.org\n Catholic Hierarchy \n\nCategory:Roman Catholic dioceses in Senegal\nCategory:Tambacounda\nCategory:Christian organizations established in 1970\nCategory:Roman Catholic dioceses and prelatures established in the 20th century History\n August 13, 1970: Established as Apostolic Prefecture of Tambacounda from the Diocese of Kaolack and Diocese of Saint-Louis du Sénégal\n April 17, 1989: Promoted as Diocese of Tambacounda\n\nSpecial churches\n Thecathedral is Cathédrale Marie Reine de l’Univers in Tambacounda, which is located in the Medina Coura neighborhood of the town. Roman Catholic Diocese of Tambacounda\n\nThe Roman Catholic Diocese of Tambacounda () is a diocese located in the city of Tambacounda in the Ecclesiastical province of Dakar in Senegal. Clément Cailleau, C.S.Sp.'}
```