### PR TITLE
Add sentence permutation data collator

### DIFF
--- a/sentence_permutation.py
+++ b/sentence_permutation.py
@@ -1,0 +1,59 @@
+import math
+from dataclasses import dataclass
+from typing import Dict
+
+import jax.numpy as jnp
+from jax import random, ops
+
+import nltk
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+
+@dataclass
+class SentenceTokenize:
+    """Tokenize the document into sentences and add bos and eos tokens"""
+
+    sentence_tokenizer = nltk.data.load("tokenizers/punkt/english.pickle")
+    eos: str = "<s>"
+    bos: str = "</s>"
+
+    def __call__(self, example: Dict[str, str]) -> Dict[str, str]:
+        sentences = self.sentence_tokenizer.tokenize(example["text"])
+        example["text"] = "".join([self.eos + sentence + self.bos for sentence in sentences])
+        return example
+
+
+@dataclass
+class DataCollatorForSentencePermutation:
+    tokenizer: PreTrainedTokenizerBase
+    permutate_sentence_ratio: float = 1.0
+    random_key = random.PRNGKey(0)
+
+    def __post_init__(self):
+        self.full_stop_index = self.tokenizer.eos_token_id
+
+    def __call__(self, example):
+        source = jnp.array(example["input_ids"])
+        full_stops = source == self.full_stop_index
+
+        # Tokens that are full stops, where the previous token is not
+        sentence_ends = (full_stops[1:] * ~full_stops[:-1]).nonzero()[0] + 2
+        result = source.clone()
+
+        num_sentences = jnp.size(sentence_ends, 0)
+        num_to_permute = math.ceil((num_sentences * 2 * self.permutate_sentence_ratio) / 2.0)
+        substitutions = random.permutation(self.random_key, num_sentences)[:num_to_permute]
+        ordering = jnp.arange(0, num_sentences)
+        ordering = ops.index_update(
+            ordering, substitutions, substitutions[random.permutation(self.random_key, num_to_permute)]
+        )
+
+        index = 0
+        for i in ordering:
+            sentence = source[(sentence_ends[i - 1] if i > 0 else 0) : sentence_ends[i]]
+            result = ops.index_update(result, ops.index[index : index + jnp.size(sentence, 0)], sentence)
+            index += jnp.size(sentence, 0)
+
+        example["input_ids"] = result
+
+        return example


### PR DESCRIPTION
The implementation is based on the implementation from fairseq: https://github.com/pytorch/fairseq/blob/1bba712622b8ae4efb3eb793a8a40da386fe11d0/fairseq/data/denoising_dataset.py#L218

Example:
```python
>>> from transformers import AutoTokenizer
>>> from sentence_permutation import SentenceTokenize, DataCollatorForSentencePermutation
>>> example = {"text": " My dog is cute. It loves to play in the park. There are many parks in SF."}
>>> sent_tok = SentenceTokenize()
>>> tokenizer = AutoTokenizer.from_pretrained("facebook/bart-base")
>>> permuate_sent = DataCollatorForSentencePermutation(tokenizer)
>>> example = sent_tok(example)
>>> example
{'text': '<s> My dog is cute.</s><s>It loves to play in the park.</s><s>There are many parks in SF.</s>'}
>>> tokenized_example = tokenizer(example["text"], add_special_tokens=False)
>>> tokenized_example = permuate_sent(tokenized_example)
>>> tokenizer.decode(tokenized_example["input_ids"])
'<s>It loves to play in the park.</s><s>There are many parks in SF.</s><s> My dog is cute.</s>'
```

They also can be use with datasets `map()`, the data flow I recommend:
```python
datasets = load_dataset(...)
datasets.map(sent_tok)  # sentence tokenized the documents and add <s>, </s> tokens as sentence separator
datasets.map(tokenize_func)  # the tokenized function here should not be adding any special tokens as the sent_tok already did it, just simply convert the text into input_ids
datasets.map(permutate_sent)  # permuate the sentences, I'm not sure if this worked with padded input_ids, need to test this
datasets.map(text_filling)  # using the DataCollatorForTextFilling for adding masks and padding 
```