### PR TITLE
add DataCollatorForDenoisingTasks

### DIFF
--- a/configuration_rotobart.py
+++ b/configuration_rotobart.py
@@ -18,7 +18,6 @@ import warnings
 from transformers.configuration_utils import PretrainedConfig
 from transformers.utils import logging
 
-
 logger = logging.get_logger(__name__)
 
 RotoBART_PRETRAINED_CONFIG_ARCHIVE_MAP = {
@@ -136,7 +135,7 @@ class RotoBARTConfig(PretrainedConfig):
         is_encoder_decoder=True,
         decoder_start_token_id=2,
         forced_eos_token_id=2,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             num_labels=num_labels,

--- a/data_collator.py
+++ b/data_collator.py
@@ -1,4 +1,13 @@
 import sys
+import math
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple, List
+
+import nltk
+import numpy as np
+from numpy.random import permutation, poisson
+from transformers.data.data_collator import _collate_batch
+from transformers.tokenization_utils_base import BatchEncoding, PreTrainedTokenizerBase
 
 # Set up TPU
 # print("Setting up colab TPU")
@@ -6,20 +15,9 @@ import sys
 # jax.tools.colab_tpu.setup_tpu()
 # print(f"Colab TPU setup complete, jax.device_count: {jax.device_count()}")
 
-import math
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, NewType, Optional, Tuple, Union
 
-import jax.numpy as jnp
-import numpy as np
-from numpy.random import poisson, permutation
-import nltk
-from jax import random, ops
+nltk.download("punkt")
 
-from transformers.tokenization_utils_base import BatchEncoding, PreTrainedTokenizerBase
-from transformers.data.data_collator import _collate_batch
-
-nltk.download('punkt')
 
 @dataclass
 class DataCollatorForTextInfilling:
@@ -32,33 +30,38 @@ class DataCollatorForTextInfilling:
         if self.tokenizer.mask_token is None:
             raise ValueError
 
-    def __call__(self, examples: List[Union[List[int], jnp.ndarray, Dict[str, jnp.ndarray]]]
-                 ) -> Dict[str, jnp.ndarray]:
-        batch = {}
+    def __call__(self, examples: List[Dict[str, np.ndarray]]) -> Dict[str, np.ndarray]:
         # Handle dict or lists with proper padding and conversion to tensor.
+        batch = {}
         if isinstance(examples, (dict, BatchEncoding)):
-            examples_ids = examples['input_ids']     
-            if 'decoder_input_ids' in examples.keys():
-                examples_dec = examples['decoder_input_ids']
+            examples_ids = examples["input_ids"]
+            if "decoder_input_ids" in examples.keys():
+                examples_dec = examples["decoder_input_ids"]
             else:
                 examples_dec = examples_ids
-            
-            #bs of one
+
+            # bs of one
             if type(examples_ids[0]) is int:
                 examples_ids = [examples_ids]
-            #bs of one
+            # bs of one
             if type(examples_dec[0]) is int:
                 examples_dec = [examples_dec]
 
-            batch["input_ids"] =  _collate_batch(examples_ids, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of)
-            batch["decoder_input_ids"] = _collate_batch(examples_dec, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of)
-            batch["decoder_input_ids"] = batch["decoder_input_ids"].tolist()
+            batch["input_ids"] = _collate_batch(
+                examples_ids, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of
+            )
+            batch["decoder_input_ids"] = _collate_batch(
+                examples_dec, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of
+            )
+            batch["decoder_input_ids"] = batch["decoder_input_ids"]
 
         elif isinstance(examples[0], (dict, BatchEncoding)):
             batch = self.tokenizer.pad(examples, return_tensors="jax", pad_to_multiple_of=self.pad_to_multiple_of)
         else:
-            batch["input_ids"] =  _collate_batch(examples, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of)
-            batch["decoder_input_ids"] =  _collate_batch(examples, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of).tolist()
+            batch["input_ids"] = _collate_batch(examples, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of)
+            batch["decoder_input_ids"] = _collate_batch(
+                examples, self.tokenizer, pad_to_multiple_of=self.pad_to_multiple_of
+            ).tolist()
 
         # If special token mask has been preprocessed, pop it from the dict.
         special_tokens_mask = batch.pop("special_tokens_mask", None)
@@ -67,16 +70,9 @@ class DataCollatorForTextInfilling:
             batch["input_ids"], special_tokens_mask=special_tokens_mask
         )
 
-        batch["input_ids"] = batch["input_ids"][0]
-        batch["decoder_input_ids"] = batch["decoder_input_ids"][0]
-        batch["labels"] = batch["labels"][0]
         return batch
 
-    def mask_tokens(self,
-                    inputs: jnp.ndarray,
-                    special_tokens_mask: Optional[jnp.ndarray] = None
-                    ) -> Tuple[jnp.ndarray, jnp.ndarray]:
-
+    def mask_tokens(self, inputs):
         inputs_copy = np.array(inputs)
         labels = np.array(inputs)
         if special_tokens_mask is None:
@@ -94,10 +90,9 @@ class DataCollatorForTextInfilling:
             return inputs, labels
 
         # generate a sufficient number of span lengths
-        #poisson_distribution = poisson(lam=self.poisson_lambda,size=(num_to_mask,))
-        lengths = poisson(lam=self.poisson_lambda,size=(num_to_mask,))
+        lengths = poisson(lam=self.poisson_lambda, size=(num_to_mask,))
         while np.cumsum(lengths, 0)[-1] < num_to_mask:
-            lengths = np.concatenate([lengths, poisson(lam=self.poisson_lambda,size=(num_to_mask,))])
+            lengths = np.concatenate([lengths, poisson(lam=self.poisson_lambda, size=(num_to_mask,))])
 
         # remove all spans of length 0
         # Note that BART inserts additional mask tokens where length == 0,
@@ -106,21 +101,21 @@ class DataCollatorForTextInfilling:
 
         # trim to about num_to_mask tokens
         idx = np.argmin(np.abs(np.cumsum(lengths, 0) - num_to_mask)) + 1
-        lengths = lengths[:idx + 1]
+        lengths = lengths[: idx + 1]
 
         # select span start indices
-        #print("IS TOKEN")
-        #print(is_token)
-        #print(sum(list(map(lambda x: 1 if(x) else 0, is_token[0]))))
-        token_indices = np.argwhere(is_token==1)
-        #print("TOKEN INDICES")
-        #print(token_indices)
-        span_starts = permutation(token_indices.shape[0])[:lengths.shape[0]]
+        # print("IS TOKEN")
+        # print(is_token)
+        # print(sum(list(map(lambda x: 1 if(x) else 0, is_token[0]))))
+        token_indices = np.argwhere(is_token == 1)
+        # print("TOKEN INDICES")
+        # print(token_indices)
+        span_starts = permutation(token_indices.shape[0])[: lengths.shape[0]]
 
         # prepare mask
         masked_indices = np.array(token_indices[span_starts])
-        #print("MASKED INDICES")
-        #print(masked_indices)
+        # print("MASKED INDICES")
+        # print(masked_indices)
         mask = np.full_like(labels, fill_value=False)
 
         # mask span start indices
@@ -139,24 +134,24 @@ class DataCollatorForTextInfilling:
             remaining = (lengths > 0) & (masked_indices[:, 1] < max_index)
 
         # place the mask tokens
-        mask[np.where(special_tokens_mask==True)] = False
-        inputs_copy[np.where(mask==1)] = self.tokenizer.mask_token_id
+        mask[np.where(special_tokens_mask == True)] = False
+        inputs_copy[np.where(mask == 1)] = self.tokenizer.mask_token_id
         labels[np.where(mask == 0)] = -100
 
         # remove mask tokens that are not starts of spans
-        to_remove = (mask == 1) & np.roll((mask == 1),1, 1)
+        to_remove = (mask == 1) & np.roll((mask == 1), 1, 1)
         new_inputs = np.full_like(labels, fill_value=self.tokenizer.pad_token_id)
 
-        #splits = list(map(lambda x: x.reshape(-1),  np.split(inputs_copy, indices_or_sections=2, axis=0))
+        # splits = list(map(lambda x: x.reshape(-1),  np.split(inputs_copy, indices_or_sections=2, axis=0))
         for i, example in enumerate(np.split(inputs_copy, indices_or_sections=new_inputs.shape[0], axis=0)):
             new_example = example[0][~to_remove[i]]
-            new_inputs[i, 0:new_example.shape[0]] = new_example
-            
-        #batching now fixed
+            new_inputs[i, 0 : new_example.shape[0]] = new_example
+
+        # batching now fixed
         return new_inputs.tolist(), labels.tolist()
 
 
-#Code below is by Matt Bui
+# Code below is by Matt Bui
 @dataclass
 class SentenceTokenize:
     """Tokenize the document into sentences and add bos and eos tokens"""
@@ -175,36 +170,33 @@ class SentenceTokenize:
 class DataCollatorForSentencePermutation:
     tokenizer: PreTrainedTokenizerBase
     permutate_sentence_ratio: float = 1.0
-    random_key = random.PRNGKey(0)
 
     def __post_init__(self):
         self.full_stop_index = self.tokenizer.eos_token_id
 
-    def __call__(self, example):
-        source = np.asarray(example["input_ids"])
-        decoder_input_ids = example["input_ids"]
+    def __call__(self, example: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+        source = example["input_ids"]
 
         full_stops = source == self.full_stop_index
 
         # Tokens that are full stops, where the previous token is not
         sentence_ends = (full_stops[1:] * ~full_stops[:-1]).nonzero()[0] + 2
         result = source.copy()
-        
+
         num_sentences = np.size(sentence_ends, 0)
         num_to_permute = math.ceil((num_sentences * 2 * self.permutate_sentence_ratio) / 2.0)
         substitutions = np.random.permutation(num_sentences)[:num_to_permute]
         ordering = np.arange(0, num_sentences)
-        ordering = ops.index_update(
-            ordering, substitutions, substitutions[np.random.permutation(num_to_permute)]
-        )
-        
+        ordering[substitutions] = substitutions[np.random.permutation(num_to_permute)]
+
         index = 0
         for i in ordering:
             sentence = source[(sentence_ends[i - 1] if i > 0 else 0) : sentence_ends[i]]
-            result = ops.index_update(result, ops.index[index : index + jnp.size(sentence, 0)], sentence)
+            result[index : index + sentence.size(0)] = sentence
             index += np.size(sentence, 0)
 
-        example["input_ids"] = np.asarray(result).tolist()
-        example['decoder_input_ids'] = decoder_input_ids
+        example["decoder_input_ids"] = example["input_ids"]
+        example["input_ids"] = result
+
         return example
 

--- a/data_collator.py
+++ b/data_collator.py
@@ -226,18 +226,19 @@ class DataCollatorForDenoisingTasks:
     mask_ratio: float = 0.3
     poisson_lambda: float = 3.0
     permutate_sentence_ratio: float = 1.0
+    pad_to_multiple_of: int = 16
 
     def __post_init__(self):
         if self.tokenizer.mask_token is None or self.tokenizer.eos_token is None:
             raise ValueError
 
-    def __call__(self, examples: List[Dict[str, List[int]]], pad_to_multiple_of: int) -> Dict[str, np.ndarray]:
+    def __call__(self, examples: List[Dict[str, List[int]]]) -> Dict[str, np.ndarray]:
         """Batching, adding whole word mask and permutate sentences
         Args:
             examples (dict): list of examples each examples contains input_ids field
         """
         # Handle dict or lists with proper padding and conversion to tensor.
-        batch = self.tokenizer.pad(examples, pad_to_multiple_of=pad_to_multiple_of, return_tensors="np")
+        batch = self.tokenizer.pad(examples, pad_to_multiple_of=self.pad_to_multiple_of, return_tensors="np")
         batch["decoder_input_ids"] = self.shift_tokens_right(batch["input_ids"])
 
         do_permutate = False

--- a/data_collator.py
+++ b/data_collator.py
@@ -202,7 +202,7 @@ class DataCollatorForSentencePermutation:
 
 
 @dataclass
-class DenoisingDataCollator:
+class DataCollatorForDenoisingTasks:
     """Data collator used denoising language modeling task in BART.
     The implementation is based on
     https://github.com/pytorch/fairseq/blob/1bba712622b8ae4efb3eb793a8a40da386fe11d0/fairseq/data/denoising_dataset.py.

--- a/data_collator.py
+++ b/data_collator.py
@@ -158,7 +158,8 @@ class SentenceTokenize:
     def __call__(self, examples: Dict[str, List[str]]) -> Dict[str, List[str]]:
         is_batched = isinstance(examples["text"], list)
         if not is_batched:
-            raise ValueError("required batched=True in map() method")
+            # raise ValueError("required batched=True in map() method")
+            examples["text"] = [examples["text"]]
 
         texts = []
         for doc in examples["text"]:

--- a/data_collator.py
+++ b/data_collator.py
@@ -200,3 +200,172 @@ class DataCollatorForSentencePermutation:
 
         return example
 
+
+@dataclass
+class DenoisingDataCollator:
+    """Data collator used denoising language modeling task in BART.
+    The implementation is based on
+    https://github.com/pytorch/fairseq/blob/1bba712622b8ae4efb3eb793a8a40da386fe11d0/fairseq/data/denoising_dataset.py.
+    The default paramters is based on BART paper https://arxiv.org/abs/1910.13461.
+    """
+
+    tokenizer: PreTrainedTokenizerBase
+    mask_ratio: float = 0.3
+    poisson_lambda: float = 3.0
+    permutate_sentence_ratio: float = 1.0
+
+    def __post_init__(self):
+        if self.tokenizer.mask_token is None or self.tokenizer.eos_token is None:
+            raise ValueError
+
+    def __call__(self, examples: List[Dict[str, List[int]]], pad_to_multiple_of: int) -> Dict[str, np.ndarray]:
+        """Batching, adding whole word mask and permutate sentences
+        Args:
+            examples (dict): list of examples each examples contains input_ids field
+        """
+        # Handle dict or lists with proper padding and conversion to tensor.
+        batch = self.tokenizer.pad(examples, pad_to_multiple_of=pad_to_multiple_of, return_tensors="np")
+        batch["decoder_input_ids"] = self.shift_tokens_right(batch["input_ids"])
+
+        do_permutate = False
+        if self.permutate_sentence_ratio > 0.0:
+            batch["input_ids"] = self.permutate_sentences(batch["input_ids"])
+            do_permutate = True
+
+        if self.mask_ratio:
+            batch["input_ids"], batch["labels"] = self.add_whole_word_mask(batch["input_ids"], do_permutate)
+
+        return batch
+
+    def shift_tokens_right(self, inputs):
+        """Shift decoder input ids right: https://github.com/huggingface/transformers/issues/7961.
+        Examples:
+            <s>My dog is cute.</s><s>It loves to play in the park.</s><pad><pad>
+            shift to -> </s><s>My dog is cute.</s><s>It loves to play in the park.<pad><pad>
+        """
+
+        shifted_inputs = np.roll(inputs, 1, axis=-1)
+
+        # replace first token with eos token
+        shifted_inputs[:, 0] = self.tokenizer.eos_token_id
+
+        # when there's padding, the last eos tokens will not be rotate to first positon
+        # we'll need to replace it with a padding token
+
+        # replace eos tokens at the end of sequences with pad tokens
+        end_with_eos = np.where(shifted_inputs[:, -1] == self.tokenizer.eos_token_id)
+        shifted_inputs[end_with_eos, -1] = self.tokenizer.pad_token_id
+
+        # find positions where where's the token is eos and its follwing token is a padding token
+        last_eos_indices = np.where(
+            (shifted_inputs[:, :-1] == self.tokenizer.eos_token_id)
+            * (shifted_inputs[:, 1:] == self.tokenizer.pad_token_id)
+        )
+
+        # replace eos tokens with pad token
+        shifted_inputs[last_eos_indices] = self.tokenizer.pad_token_id
+        return shifted_inputs
+
+    def permutate_sentences(self, inputs):
+        results = inputs.copy()
+
+        full_stops = inputs == self.tokenizer.eos_token_id
+
+        sentence_ends = np.argwhere(full_stops[:, 1:] * ~full_stops[:, :-1])
+        sentence_ends[:, 1] += 2
+        num_sentences = np.unique(sentence_ends[:, 0], return_counts=True)[1]
+        num_to_permute = np.ceil((num_sentences * 2 * self.permutate_sentence_ratio) / 2.0).astype(int)
+
+        sentence_ends = np.split(sentence_ends[:, 1], np.unique(sentence_ends[:, 0], return_index=True)[1][1:])
+
+        for i in range(inputs.shape[0]):
+            substitutions = np.random.permutation(num_sentences[i])[: num_to_permute[i]]
+
+            ordering = np.arange(0, num_sentences[i])
+            ordering[substitutions] = substitutions[np.random.permutation(num_to_permute[i])]
+
+            index = 0
+            for j in ordering:
+                sentence = inputs[i, (sentence_ends[i][j - 1] if j > 0 else 0) : sentence_ends[i][j]]
+                results[i, index : index + sentence.shape[0]] = sentence
+                index += sentence.shape[0]
+        return results
+
+    def add_whole_word_mask(self, inputs, do_permutate):
+        labels = inputs.copy()
+
+        special_tokens_mask = [
+            self.tokenizer.get_special_tokens_mask(val, already_has_special_tokens=True) for val in labels.tolist()
+        ]
+        special_tokens_mask = np.array(special_tokens_mask, dtype=bool)
+
+        # determine how many tokens we need to mask in total
+        is_token = ~(labels == self.tokenizer.pad_token_id) & ~special_tokens_mask
+        num_to_mask = int(math.ceil(is_token.astype(float).sum() * self.mask_ratio))
+        if num_to_mask == 0:
+            return inputs, labels
+
+        # generate a sufficient number of span lengths
+        lengths = poisson(lam=self.poisson_lambda, size=(num_to_mask,))
+        while np.cumsum(lengths, 0)[-1] < num_to_mask:
+            lengths = np.concatenate([lengths, poisson(lam=self.poisson_lambda, size=(num_to_mask,))])
+
+        # remove all spans of length 0
+        # Note that BART inserts additional mask tokens where length == 0,
+        # which we do not implement for now as it adds additional complexity
+        lengths = lengths[lengths > 0]
+
+        # trim to about num_to_mask tokens
+        idx = np.argmin(np.abs(np.cumsum(lengths, 0) - num_to_mask)) + 1
+        lengths = lengths[: idx + 1]
+
+        # select span start indices
+        # print("IS TOKEN")
+        # print(is_token)
+        # print(sum(list(map(lambda x: 1 if(x) else 0, is_token[0]))))
+        token_indices = np.argwhere(is_token == 1)
+        # print("TOKEN INDICES")
+        # print(token_indices)
+        span_starts = permutation(token_indices.shape[0])[: lengths.shape[0]]
+
+        # prepare mask
+        masked_indices = np.array(token_indices[span_starts])
+        # print("MASKED INDICES")
+        # print(masked_indices)
+        mask = np.full_like(labels, fill_value=False)
+
+        # mask span start indices
+        for mi in masked_indices:
+            mask[tuple(mi)] = True
+        lengths -= 1
+
+        # fill up spans
+        max_index = labels.shape[1] - 1
+        remaining = (lengths > 0) & (masked_indices[:, 1] < max_index)
+        while np.any(remaining):
+            masked_indices[remaining, 1] += 1
+            for mi in masked_indices:
+                mask[tuple(mi)] = True
+            lengths -= 1
+            remaining = (lengths > 0) & (masked_indices[:, 1] < max_index)
+
+        # place the mask tokens
+        mask[np.where(special_tokens_mask)] = False
+        inputs[np.where(mask)] = self.tokenizer.mask_token_id
+
+        if not do_permutate:
+            labels[np.where(mask)] = -100
+        else:
+            labels[np.where(special_tokens_mask)] = -100
+
+        # remove mask tokens that are not starts of spans
+        to_remove = (mask == 1) & np.roll((mask == 1), 1, 1)
+        new_inputs = np.full_like(labels, fill_value=self.tokenizer.pad_token_id)
+
+        # splits = list(map(lambda x: x.reshape(-1),  np.split(inputs_copy, indices_or_sections=2, axis=0))
+        for i, example in enumerate(np.split(inputs, indices_or_sections=new_inputs.shape[0], axis=0)):
+            new_example = example[0][~to_remove[i]]
+            new_inputs[i, 0 : new_example.shape[0]] = new_example
+
+        # batching now fixed
+        return new_inputs, labels

--- a/data_collator.py
+++ b/data_collator.py
@@ -166,11 +166,11 @@ class SentenceTokenize:
             start_index = 0
             while start_index < len(sentences):
                 sentence_span = sentences[start_index : min(len(sentences), start_index + self.max_sentences)]
-                text = "".join([self.bos + sentence + self.eos for sentence in sentence_span])
+                text = f"{self.eos}{self.bos}".join([sentence for sentence in sentence_span])
 
                 # trim text by max characters
                 if len(text) > self.max_characters:
-                    text = text[: self.max_characters - len(self.eos)] + self.eos
+                    text = text[: self.max_characters]
                 texts.append(text)
                 start_index += self.sentence_stride
 

--- a/data_collator.py
+++ b/data_collator.py
@@ -1,7 +1,7 @@
-import sys
 import math
+import sys
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple, List
+from typing import Dict, List, Optional, Tuple
 
 import nltk
 import numpy as np

--- a/modeling_flax_rotobart.py
+++ b/modeling_flax_rotobart.py
@@ -764,10 +764,10 @@ class FlaxRotoBARTEncoder(nn.Module):
         input_ids = input_ids.reshape(-1, input_shape[-1])
 
         inputs_embeds = self.embed_tokens(input_ids) * self.embed_scale
-        #embed_pos = self.embed_positions(position_ids + self.offset)    
-        #position_ids = position_ids.asarray()
-        
-        hidden_states = inputs_embeds #+ embed_pos
+        # embed_pos = self.embed_positions(position_ids + self.offset)
+        # position_ids = position_ids.asarray()
+
+        hidden_states = inputs_embeds  # + embed_pos
         hidden_states = self.layernorm_embedding(hidden_states)
         hidden_states = self.dropout_layer(hidden_states, deterministic=deterministic)
 

--- a/modeling_flax_rotobart.py
+++ b/modeling_flax_rotobart.py
@@ -27,7 +27,6 @@ from flax.linen import combine_masks, make_causal_mask
 from flax.linen.attention import dot_product_attention_weights
 from jax import lax
 from jax.random import PRNGKey
-
 from transformers.file_utils import add_start_docstrings, replace_return_docstrings
 from transformers.modeling_flax_outputs import (
     FlaxBaseModelOutput,
@@ -40,15 +39,17 @@ from transformers.modeling_flax_outputs import (
 )
 from transformers.modeling_flax_utils import (
     ACT2FN,
-    FlaxPreTrainedModel,
     append_call_sample_docstring,
     append_replace_return_docstrings,
+    FlaxPreTrainedModel,
     overwrite_call_docstring,
 )
 from transformers.utils import logging
+
 from configuration_rotobart import RotoBARTConfig
 from rotobart_utils import *
-#from transformers.models.RotoBART.configuration_RotoBART import RotoBARTConfig
+
+# from transformers.models.RotoBART.configuration_RotoBART import RotoBARTConfig
 
 
 logger = logging.get_logger(__name__)
@@ -237,9 +238,9 @@ class FlaxRotoBARTAttention(nn.Module):
 
     def setup(self) -> None:
         self.head_dim = self.embed_dim // self.num_heads
-        
-        #Rotary applied to the first half of the dimensions
-        self.pe_rotary_dims = self.head_dim //2
+
+        # Rotary applied to the first half of the dimensions
+        self.pe_rotary_dims = self.head_dim // 2
 
         assert (
             self.head_dim * self.num_heads == self.embed_dim
@@ -327,28 +328,27 @@ class FlaxRotoBARTAttention(nn.Module):
         else:
             # self_attention
             key_states = self.k_proj(hidden_states)
-            value_states = self.v_proj(hidden_states)        
+            value_states = self.v_proj(hidden_states)
 
         query_states = self._split_heads(query_states)
         key_states = self._split_heads(key_states)
         value_states = self._split_heads(value_states)
 
-        #Apply rotary positional embeddings
-        k_rot = key_states[:, :, :, :self.pe_rotary_dims]
-        k_pass = key_states[:, :, :, self.pe_rotary_dims:]
+        # Apply rotary positional embeddings
+        k_rot = key_states[:, :, :, : self.pe_rotary_dims]
+        k_pass = key_states[:, :, :, self.pe_rotary_dims :]
 
-        q_rot = query_states[:, :, :, :self.pe_rotary_dims]
-        q_pass = query_states[:, :, :, self.pe_rotary_dims:]
+        q_rot = query_states[:, :, :, : self.pe_rotary_dims]
+        q_pass = query_states[:, :, :, self.pe_rotary_dims :]
 
-        #print(k_rot.shape)
+        # print(k_rot.shape)
         sincos = fixed_pos_embedding(k_rot, seq_dim=1, position_ids=position_ids)
         q_rot = apply_rotary_pos_emb(q_rot, sincos, offset=0)
         k_rot = apply_rotary_pos_emb(k_rot, sincos, offset=0)
 
-        #Concat back together
+        # Concat back together
         key_states = jnp.concatenate([k_rot, k_pass], axis=-1)
         query_states = jnp.concatenate([q_rot, q_pass], axis=-1)
-
 
         # handle cache prepare causal attention mask
         if self.causal:
@@ -371,9 +371,6 @@ class FlaxRotoBARTAttention(nn.Module):
             attention_mask = causal_mask
         elif attention_mask is not None:
             attention_mask = jnp.expand_dims(attention_mask, axis=(-3, -2))
-
-
-
 
         # During fast autoregressive decoding, we feed one position at a time,
         # and cache the keys and values step by step.
@@ -451,7 +448,9 @@ class FlaxRotoBARTEncoderLayer(nn.Module):
         deterministic: bool = True,
     ) -> Tuple[jnp.ndarray]:
         residual = hidden_states
-        hidden_states, attn_weights = self.self_attn(hidden_states=hidden_states, attention_mask=attention_mask, position_ids=position_ids)
+        hidden_states, attn_weights = self.self_attn(
+            hidden_states=hidden_states, attention_mask=attention_mask, position_ids=position_ids
+        )
 
         hidden_states = self.dropout_layer(hidden_states, deterministic=deterministic)
         hidden_states = residual + hidden_states
@@ -476,9 +475,11 @@ class FlaxRotoBARTEncoderLayer(nn.Module):
 class FlaxRotoBARTEncoderLayerCollection(nn.Module):
     config: RotoBARTConfig
     dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
     def setup(self):
         self.layers = [
-            FlaxRotoBARTEncoderLayer(self.config, name=str(i), dtype=self.dtype) for i in range(self.config.encoder_layers)
+            FlaxRotoBARTEncoderLayer(self.config, name=str(i), dtype=self.dtype)
+            for i in range(self.config.encoder_layers)
         ]
         self.layerdrop = self.config.encoder_layerdrop
 
@@ -530,6 +531,7 @@ class FlaxRotoBARTEncoderLayerCollection(nn.Module):
 class FlaxRotoBARTDecoderLayer(nn.Module):
     config: RotoBARTConfig
     dtype: jnp.dtype = jnp.float32
+
     def setup(self) -> None:
         self.embed_dim = self.config.d_model
         self.self_attn = FlaxRotoBARTAttention(
@@ -565,7 +567,7 @@ class FlaxRotoBARTDecoderLayer(nn.Module):
         self,
         hidden_states: jnp.ndarray,
         attention_mask: jnp.ndarray,
-        position_ids : jnp.ndarray,
+        position_ids: jnp.ndarray,
         encoder_hidden_states: Optional[jnp.ndarray] = None,
         encoder_attention_mask: Optional[jnp.ndarray] = None,
         init_cache: bool = False,
@@ -617,9 +619,11 @@ class FlaxRotoBARTDecoderLayer(nn.Module):
 class FlaxRotoBARTDecoderLayerCollection(nn.Module):
     config: RotoBARTConfig
     dtype: jnp.dtype = jnp.float32  # the dtype of the computation
+
     def setup(self):
         self.layers = [
-            FlaxRotoBARTDecoderLayer(self.config, name=str(i), dtype=self.dtype) for i in range(self.config.decoder_layers)
+            FlaxRotoBARTDecoderLayer(self.config, name=str(i), dtype=self.dtype)
+            for i in range(self.config.decoder_layers)
         ]
         self.layerdrop = self.config.decoder_layerdrop
 
@@ -761,9 +765,9 @@ class FlaxRotoBARTEncoder(nn.Module):
 
         inputs_embeds = self.embed_tokens(input_ids) * self.embed_scale
 
-        #embed_pos = self.embed_positions(position_ids + self.offset)    
+        # embed_pos = self.embed_positions(position_ids + self.offset)
 
-        hidden_states = inputs_embeds #+ embed_pos
+        hidden_states = inputs_embeds  # + embed_pos
         hidden_states = self.layernorm_embedding(hidden_states)
         hidden_states = self.dropout_layer(hidden_states, deterministic=deterministic)
 
@@ -840,9 +844,9 @@ class FlaxRotoBARTDecoder(nn.Module):
         inputs_embeds = self.embed_tokens(input_ids) * self.embed_scale
 
         # embed positions
-        #positions = self.embed_positions(position_ids + self.offset)
+        # positions = self.embed_positions(position_ids + self.offset)
 
-        hidden_states = inputs_embeds #+ positions
+        hidden_states = inputs_embeds  # + positions
         hidden_states = self.layernorm_embedding(hidden_states)
 
         hidden_states = self.dropout_layer(hidden_states, deterministic=deterministic)
@@ -952,7 +956,7 @@ class FlaxRotoBARTPreTrainedModel(FlaxPreTrainedModel):
         input_shape: Tuple[int] = (1, 1),
         seed: int = 0,
         dtype: jnp.dtype = jnp.float32,
-        **kwargs
+        **kwargs,
     ):
         module = self.module_class(config=config, dtype=dtype, **kwargs)
         super().__init__(config, module, input_shape=input_shape, seed=seed, dtype=dtype)
@@ -1142,9 +1146,7 @@ class FlaxRotoBARTPreTrainedModel(FlaxPreTrainedModel):
             if past_key_values is not None:
                 raise ValueError("Make sure to provide `decoder_position_ids` when passing `past_key_values`.")
 
-            decoder_position_ids = jnp.broadcast_to(
-                jnp.arange(sequence_length)[None, :], (batch_size, sequence_length)
-            )
+            decoder_position_ids = jnp.broadcast_to(jnp.arange(sequence_length)[None, :], (batch_size, sequence_length))
 
         # Handle any PRNG if needed
         rngs = {}
@@ -1235,9 +1237,7 @@ class FlaxRotoBARTPreTrainedModel(FlaxPreTrainedModel):
             decoder_attention_mask = jnp.ones_like(decoder_input_ids)
         if decoder_position_ids is None:
             batch_size, sequence_length = decoder_input_ids.shape
-            decoder_position_ids = jnp.broadcast_to(
-                jnp.arange(sequence_length)[None, :], (batch_size, sequence_length)
-            )
+            decoder_position_ids = jnp.broadcast_to(jnp.arange(sequence_length)[None, :], (batch_size, sequence_length))
 
         # Handle any PRNG if needed
         rngs = {"dropout": dropout_rng} if dropout_rng is not None else {}
@@ -1258,12 +1258,10 @@ class FlaxRotoBARTPreTrainedModel(FlaxPreTrainedModel):
         )
 
 
-
 class FlaxRotoBARTModel(FlaxRotoBARTPreTrainedModel):
     config: RotoBARTConfig
     dtype: jnp.dtype = jnp.float32  # the dtype of the computation
     module_class = FlaxRotoBARTModule
-
 
 
 append_call_sample_docstring(
@@ -1402,9 +1400,7 @@ class FlaxRotoBARTForConditionalGeneration(FlaxRotoBARTPreTrainedModel):
             if past_key_values is not None:
                 raise ValueError("Make sure to provide `decoder_position_ids` when passing `past_key_values`.")
 
-            decoder_position_ids = jnp.broadcast_to(
-                jnp.arange(sequence_length)[None, :], (batch_size, sequence_length)
-            )
+            decoder_position_ids = jnp.broadcast_to(jnp.arange(sequence_length)[None, :], (batch_size, sequence_length))
 
         # Handle any PRNG if needed
         rngs = {}
@@ -1481,7 +1477,6 @@ class FlaxRotoBARTForConditionalGeneration(FlaxRotoBARTPreTrainedModel):
 
         return outputs
 
-
     def prepare_inputs_for_generation(
         self,
         decoder_input_ids,
@@ -1489,7 +1484,7 @@ class FlaxRotoBARTForConditionalGeneration(FlaxRotoBARTPreTrainedModel):
         attention_mask: Optional[jnp.DeviceArray] = None,
         decoder_attention_mask: Optional[jnp.DeviceArray] = None,
         encoder_outputs=None,
-        **kwargs
+        **kwargs,
     ):
         # initializing the cache
         batch_size, seq_length = decoder_input_ids.shape
@@ -1517,7 +1512,6 @@ class FlaxRotoBARTForConditionalGeneration(FlaxRotoBARTPreTrainedModel):
         model_kwargs["past_key_values"] = model_outputs.past_key_values
         model_kwargs["decoder_position_ids"] = model_kwargs["decoder_position_ids"][:, -1:] + 1
         return model_kwargs
-
 
 
 FLAX_RotoBART_CONDITIONAL_GENERATION_DOCSTRING = """
@@ -1641,10 +1635,10 @@ class FlaxRotoBARTForSequenceClassificationModule(nn.Module):
             encoder_attentions=outputs.encoder_attentions,
         )
 
+
 class FlaxRotoBARTForSequenceClassification(FlaxRotoBARTPreTrainedModel):
     module_class = FlaxRotoBARTForSequenceClassificationModule
     dtype = jnp.float32
-
 
 
 append_call_sample_docstring(
@@ -1725,7 +1719,6 @@ class FlaxRotoBARTForQuestionAnsweringModule(nn.Module):
 class FlaxRotoBARTForQuestionAnswering(FlaxRotoBARTPreTrainedModel):
     module_class = FlaxRotoBARTForQuestionAnsweringModule
     dtype = jnp.float32
-
 
 
 append_call_sample_docstring(

--- a/pile.py
+++ b/pile.py
@@ -4,7 +4,8 @@ import os
 import datasets
 import jsonlines
 import zstandard as zstd
-#from lm_dataformat import Reader
+
+# from lm_dataformat import Reader
 
 
 logger = datasets.logging.get_logger(__name__)

--- a/pile.py
+++ b/pile.py
@@ -1,5 +1,6 @@
-import datasets
 import io
+
+import datasets
 import jsonlines
 import zstandard as zstd
 

--- a/pile.py
+++ b/pile.py
@@ -1,4 +1,5 @@
 import io
+import os
 
 import datasets
 import jsonlines
@@ -29,10 +30,33 @@ class Pile(datasets.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager):
-        return [
-            datasets.SplitGenerator(name=split, gen_kwargs={"filepaths": dl_manager.download(_URLS[split])})
-            for split in _URLS
-        ]
+        if self.config.data_files is None:
+            return [
+                datasets.SplitGenerator(name=split, gen_kwargs={"filepaths": dl_manager.download(_URLS[split])})
+                for split in _URLS
+            ]
+        data_files = dl_manager.download_and_extract(self.config.data_files)
+        if isinstance(data_files, (str, list, tupe)):
+            if isinstance(data_files, str):
+                if os.path.isdir(data_files):
+                    data_files = [
+                        os.path.join(data_files, filename)
+                        for filename in os.listdir(data_files)
+                        if filename.endswith("zst")
+                    ]
+                else:
+                    data_files = [data_files]
+            return [datasets.SplitGenerator(name=datasets.Split.TRAIN, gen_kwargs={"filepaths": data_files})]
+        splits = []
+        for split_name, files in data_files.items():
+            if isinstance(files, str):
+                if os.path.isdir(files):
+                    files = [
+                        os.path.join(files, filename) for filename in os.listdir(files) if filename.endswith("zst")
+                    ]
+                else:
+                    files = [data_files]
+            splits.append(datasets.SplitGenerator(name=split_name, gen_kwargs={"filepaths": files}))
 
     def _generate_examples(self, filepaths):
         id_ = 0

--- a/pile.py
+++ b/pile.py
@@ -35,8 +35,8 @@ class Pile(datasets.GeneratorBasedBuilder):
                 datasets.SplitGenerator(name=split, gen_kwargs={"filepaths": dl_manager.download(_URLS[split])})
                 for split in _URLS
             ]
-        data_files = dl_manager.download_and_extract(self.config.data_files)
-        if isinstance(data_files, (str, list, tupe)):
+        data_files = self.config.data_files
+        if isinstance(data_files, (str, list, tuple)):
             if isinstance(data_files, str):
                 if os.path.isdir(data_files):
                     data_files = [

--- a/rotobart_utils.py
+++ b/rotobart_utils.py
@@ -1,9 +1,9 @@
-import numpy as np
 import jax.numpy as jnp
+import numpy as np
 from einops import rearrange, repeat
 
-#Taken from Ben Wang's mesh-transformer-jax implementation
-#https://github.com/kingoflolz/mesh-transformer-jax
+# Taken from Ben Wang's mesh-transformer-jax implementation
+# https://github.com/kingoflolz/mesh-transformer-jax
 
 
 def fixed_pos_embedding(x, seq_dim=1, seq_len=None, position_ids=None):
@@ -13,16 +13,18 @@ def fixed_pos_embedding(x, seq_dim=1, seq_len=None, position_ids=None):
     if position_ids is None:
         position_ids = np.arange(seq_len)
 
-    inv_freq = 1. / (10000 ** (np.arange(0, dim, 2) / dim))
-    sinusoid_inp = jnp.einsum('i... , j -> i... j', position_ids, inv_freq)
+    inv_freq = 1.0 / (10000 ** (np.arange(0, dim, 2) / dim))
+    sinusoid_inp = jnp.einsum("i... , j -> i... j", position_ids, inv_freq)
     return jnp.sin(sinusoid_inp), jnp.cos(sinusoid_inp)
+
 
 def rotate_every_two(x):
     x1 = x[:, :, :, ::2]
     x2 = x[:, :, :, 1::2]
     x = jnp.stack((-x2, x1), axis=-1)
-    return rearrange(x, '... d j -> ... (d j)')
+    return rearrange(x, "... d j -> ... (d j)")
+
 
 def apply_rotary_pos_emb(x, sincos, offset=0):
-    sin, cos = map(lambda t: repeat(t[:, offset:x.shape[1]+offset,:], "b n d -> b n () (d j)", j=2), sincos)
+    sin, cos = map(lambda t: repeat(t[:, offset : x.shape[1] + offset, :], "b n d -> b n () (d j)", j=2), sincos)
     return (x * cos) + (rotate_every_two(x) * sin)

--- a/run_dnlm_flax.py
+++ b/run_dnlm_flax.py
@@ -107,26 +107,16 @@ class ModelArguments:
     )
     decoder_ffn_dim: Optional[int] = field(
         default=256,
-        metadata={
-            "help": "Dimension of decoder feedforward network"
-        },
+        metadata={"help": "Dimension of decoder feedforward network"},
     )
-    decoder_ffn_dim: Optional[int] = field(default=256,
-        metadata={"help": "Dimension of decoder feedforward network"})
-    d_model: Optional[int] = field(default=1024,
-        metadata={"help": "Dimension of model"})
-    vocab_size: Optional[int] = field(default=128100,
-        metadata={"help": "Vocab size"})
-    max_position_embeddings: Optional[int] = field(default=1024,
-        metadata={"help": "Max position embeddings"})
-    encoder_layerdrop: Optional[float] = field(default=0.0,
-        metadata={"help": "Max position embeddings"})
-    decoder_layerdrop: Optional[float] = field(default=0.0,
-        metadata={"help": "Max position embeddings"})
-    use_bf16: bool = field( default=False,
-        metadata={"help": "Train in bf16 or not"})
-    grad_accum: Optional[int] = field(default=4,
-        metadata={"help": "Number of steps to accumulate gradients over"})
+    decoder_ffn_dim: Optional[int] = field(default=256, metadata={"help": "Dimension of decoder feedforward network"})
+    d_model: Optional[int] = field(default=1024, metadata={"help": "Dimension of model"})
+    vocab_size: Optional[int] = field(default=128100, metadata={"help": "Vocab size"})
+    max_position_embeddings: Optional[int] = field(default=1024, metadata={"help": "Max position embeddings"})
+    encoder_layerdrop: Optional[float] = field(default=0.0, metadata={"help": "Max position embeddings"})
+    decoder_layerdrop: Optional[float] = field(default=0.0, metadata={"help": "Max position embeddings"})
+    use_bf16: bool = field(default=False, metadata={"help": "Train in bf16 or not"})
+    grad_accum: Optional[int] = field(default=4, metadata={"help": "Number of steps to accumulate gradients over"})
 
 
 @dataclass
@@ -209,8 +199,8 @@ def advance_iter_and_group_samples(train_iterator, num_samples, max_seq_length):
     i = 0
     while i < num_total_tokens:
         tokenized_samples = next(train_iterator)
-        tokenized_samples['input_ids'] = tokenized_samples['input_ids'].tolist()
-        tokenized_samples['labels'] = tokenized_samples['labels'].tolist()
+        tokenized_samples["input_ids"] = tokenized_samples["input_ids"].tolist()
+        tokenized_samples["labels"] = tokenized_samples["labels"].tolist()
 
         i += len(tokenized_samples["input_ids"][0])
         # concatenate tokenized samples to list
@@ -301,47 +291,41 @@ if __name__ == "__main__":
 
     # Set seed before initializing model.
     set_seed(training_args.seed)
-    wikitext=(data_args.dataset_path == 'wikitext')
+    wikitext = data_args.dataset_path == "wikitext"
     if not wikitext:
         # Load Datasets
         # Train Dataset - Stream The Pile dataset
-        print('Loading train data')
+        print("Loading train data")
         train_dataset = load_dataset(
-        data_args.dataset_path, 
-        split="train",
-        cache_dir=model_args.cache_dir,
-        streaming=True)
+            data_args.dataset_path, split="train", cache_dir=model_args.cache_dir, streaming=True
+        )
 
-        print('Loading eval data')
+        print("Loading eval data")
         # Test Dataset - Stream The Pile dataset
-            
+
         eval_dataset = load_dataset(
-        data_args.dataset_path, 
-        split="validation",
-        streaming=True,
-        cache_dir=model_args.cache_dir,
+            data_args.dataset_path,
+            split="validation",
+            streaming=True,
+            cache_dir=model_args.cache_dir,
         )
     else:
         # Load Datasets
         # Train Dataset - Stream The Pile dataset
-        print('Loading train data')
+        print("Loading train data")
         train_dataset = load_dataset(
-        data_args.dataset_path,
-        'wikitext-103-raw-v1', 
-        split="train",
-        cache_dir=model_args.cache_dir,
-        streaming=True)
+            data_args.dataset_path, "wikitext-103-raw-v1", split="train", cache_dir=model_args.cache_dir, streaming=True
+        )
 
-        print('Loading eval data')
+        print("Loading eval data")
         # Test Dataset - Stream The Pile dataset
 
-            
         eval_dataset = load_dataset(
-        data_args.dataset_path,
-        'wikitext-103-raw-v1',
-        split="validation",
-        streaming=True,
-        cache_dir=model_args.cache_dir,
+            data_args.dataset_path,
+            "wikitext-103-raw-v1",
+            split="validation",
+            streaming=True,
+            cache_dir=model_args.cache_dir,
         )
 
     # Shuffle the training dataset
@@ -515,7 +499,7 @@ if __name__ == "__main__":
             weight_decay=training_args.weight_decay,
             mask=decay_mask_fn,
         )
-    clip=1.0
+    clip = 1.0
     my_optimizer = optax.chain(
         optax.clip_by_global_norm(clip),
         optimizer,

--- a/run_dnlm_flax.py
+++ b/run_dnlm_flax.py
@@ -373,7 +373,10 @@ if __name__ == "__main__":
     # e.g: {"input_ids": [[1,2,3,4]]} -> {"input_ids": [1,2,3,4]}
     def flatten(example):
         for k, v in example.items():
-            example[k] = v[0]
+			if isinstance(v[0], list):
+                example[k] = v[0]
+            else:
+                example[k] = v
         return example
     shuffled_train_dataset = shuffled_train_dataset.map(flatten)
 

--- a/sentence_permutation.py
+++ b/sentence_permutation.py
@@ -1,29 +1,26 @@
 import math
 from dataclasses import dataclass
 from typing import Dict
-import numpy as np
 
 import jax.numpy as jnp
-from jax import random, ops
-
 import nltk
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-from data_collator import DataCollatorForTextInfilling, SentenceTokenize, DataCollatorForSentencePermutation
-
-
-
-
+import numpy as np
+from jax import ops, random
 from transformers import AutoTokenizer
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from data_collator import DataCollatorForSentencePermutation, DataCollatorForTextInfilling, SentenceTokenize
+
 example = {"text": " My dog is cute. It loves to play in the park. There are many parks in SF."}
 sent_tok = SentenceTokenize()
 tokenizer = AutoTokenizer.from_pretrained("facebook/bart-base")
 permuate_sent = DataCollatorForSentencePermutation(tokenizer)
 example = sent_tok(example)
-print(example['text'])
-out = permuate_sent(tokenizer(example['text'], add_special_tokens=False))
-example['text'] = tokenizer.decode(out['input_ids'])
-print(example['text'])
+print(example["text"])
+out = permuate_sent(tokenizer(example["text"], add_special_tokens=False))
+example["text"] = tokenizer.decode(out["input_ids"])
+print(example["text"])
 masking = DataCollatorForTextInfilling(tokenizer)
 out = masking(out)
-example['text'] = tokenizer.decode(out['input_ids'][0])
-print(example['text'])
+example["text"] = tokenizer.decode(out["input_ids"][0])
+print(example["text"])

--- a/test.py
+++ b/test.py
@@ -1,14 +1,14 @@
-from modeling_flax_rotobart import *
-from configuration_rotobart import *
 from transformers import BartTokenizer
+
+from configuration_rotobart import *
 from data_collator import DataCollatorForTextInfilling
+from modeling_flax_rotobart import *
 
-config = RotoBARTConfig(encoder_layers=2, \
-    encoder_ffn_dim=256, decoder_layers=2, decoder_ffn_dim=256)
+config = RotoBARTConfig(encoder_layers=2, encoder_ffn_dim=256, decoder_layers=2, decoder_ffn_dim=256)
 
-#model = FlaxRotoBARTModel(config=config)
-tokenizer = BartTokenizer.from_pretrained('facebook/bart-large-cnn')
-special_tokens_dict = {'additional_special_tokens': ['[MASK]']}
+# model = FlaxRotoBARTModel(config=config)
+tokenizer = BartTokenizer.from_pretrained("facebook/bart-large-cnn")
+special_tokens_dict = {"additional_special_tokens": ["[MASK]"]}
 tokenizer.add_special_tokens(special_tokens_dict)
 
 
@@ -25,5 +25,5 @@ collator = DataCollatorForTextInfilling(tokenizer)
 
 print(collator(inputs))
 
-#print(inputs)
-#model.encode(**inputs)
+# print(inputs)
+# model.encode(**inputs)

--- a/test.py
+++ b/test.py
@@ -7,11 +7,9 @@ from modeling_flax_rotobart import *
 config = RotoBARTConfig(encoder_layers=2, encoder_ffn_dim=256, decoder_layers=2, decoder_ffn_dim=256)
 
 model = FlaxRotoBARTModel(config=config)
-tokenizer = BartTokenizer.from_pretrained('facebook/bart-large-cnn')
-special_tokens_dict = {'additional_special_tokens': ['[MASK]']}
+tokenizer = BartTokenizer.from_pretrained("facebook/bart-large-cnn")
+special_tokens_dict = {"additional_special_tokens": ["[MASK]"]}
 tokenizer.add_special_tokens(special_tokens_dict)
-
-
 
 
 lorem_ispum = """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nec feugiat nisl pretium fusce id. Odio ut enim blandit volutpat maecenas volutpat. Tincidunt dui ut ornare lectus sit amet est placerat. Non tellus orci ac auctor augue. Gravida quis blandit turpis cursus in. Pharetra vel turpis nunc eget lorem. Sit amet cursus sit amet dictum sit amet justo. Ipsum consequat nisl vel pretium lectus quam. At in tellus integer feugiat scelerisque varius morbi. Risus nec feugiat in fermentum. In ante metus dictum at tempor commodo ullamcorper a lacus. Id neque aliquam vestibulum morbi blandit cursus risus at. Elementum pulvinar etiam non quam lacus suspendisse faucibus interdum posuere. Integer feugiat scelerisque varius morbi enim nunc faucibus a pellentesque. Sit amet cursus sit amet. Cursus mattis molestie a iaculis at erat pellentesque. Sed sed risus pretium quam vulputate dignissim suspendisse. Eu feugiat pretium nibh ipsum consequat nisl vel pretium.
@@ -22,10 +20,10 @@ Molestie ac feugiat sed lectus vestibulum mattis. Ut sem nulla pharetra diam sit
 """
 print("JAX")
 inputs = tokenizer(lorem_ispum, max_length=1024, padding=True, truncation=True, return_tensors="np")
-#print(inputs)
-#collator = DataCollatorForTextInfilling(tokenizer)
+# print(inputs)
+# collator = DataCollatorForTextInfilling(tokenizer)
 
-#print(collator(inputs))
+# print(collator(inputs))
 
 print(inputs)
 model.encode(**inputs)


### PR DESCRIPTION
## Added
- New data collator class `DataCollatorForDenoisingTasks`, which is more accurate to https://github.com/pytorch/fairseq/blob/1bba712622b8ae4efb3eb793a8a40da386fe11d0/fairseq/data/denoising_dataset.py
	- Add shift_tokens_right for decoder_input_ids
- Pytorch DataLoader for batching
- `SentenceTokenize` will split long texts into smaller chunks when encountering long input text to speed up the tokenizer.
- Add `data_files` parameters for load pile dataset locally:
```python
from datasets import load_dataset
data_files={
	"train": "./data/train_files",
	"validation": "./data/...zst",
	"test": "./data/...zst"
}
dataset = load_dataset("./pile.py", data_files=data_files) # set streaming=True here also fine, it will load the dataset on the fly.
```

## Changes
- Replace grouping texts and manual iterate for batching with PyTorch DataLoader
- Reduce shuffle_buffer_size for better data loading startup, `shuffer_buffer_size = 1000` is still make start-up time slow, but it's good enough

Here's the new data flow:
```python
dataset = load_dataset(...)

sent_tok = SentenceTokenize()
dataset = dataset.map(sent_tok, batched=True, batch_size=1) # batched=True as the number of examples changed due to split up long doc

def tokenizer_fn(...):
	...
dataset = dataset.map(tokenizer_fn, bathed=True, batch_size=1)

data_collator = DataCollatorForDenoisingTasks(tokenizer)

iter = BackgroundGenerator(DataLoader(dataset, batch_size=2, collate_fn=data_collator))
```

Fixed #20 